### PR TITLE
Evan perry/jest start

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @EvanPrograms

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Typecheck
         run: npm run -s typecheck
 
+      - name: Test (Jest)
+        run: npm run -s test:ci
+
       - name: Prettier check
         run: npm run -s format:check
 

--- a/frontend/.prettierrc.json
+++ b/frontend/.prettierrc.json
@@ -6,5 +6,5 @@
   "semi": true,
   "arrowParens": "always",
   "bracketSpacing": true,
-  "endOfLine": "lf"
+  "endOfLine": "auto"
 }

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -101,7 +101,7 @@ module.exports = [
       '@typescript-eslint/no-explicit-any': 'off',
 
       // Formatting: enforce Prettier (auto-fixable).
-      'prettier/prettier': 'error',
+      'prettier/prettier': ['error', { endOfLine: 'auto' }],
     },
   },
 

--- a/frontend/src/features/chat/renderChatListItem.tsx
+++ b/frontend/src/features/chat/renderChatListItem.tsx
@@ -7,6 +7,7 @@ import type { ChatScreenStyles } from '../../screens/ChatScreen.styles';
 import { APP_COLORS, PALETTE, withAlpha } from '../../theme/colors';
 import type { MediaItem } from '../../types/media';
 import { shouldShowIncomingAvatar } from '../../utils/avatarGrouping';
+import { formatMessageMetaTimestamp } from '../../utils/chatDates';
 import { getOlderNeighbor } from '../../utils/listNeighbors';
 import {
   isImageLike as isImageLikeMedia,
@@ -148,14 +149,7 @@ export function renderChatListItem(args: {
     );
   }
 
-  const timestamp = new Date(item.createdAt);
-  const now = new Date();
-  const isToday =
-    timestamp.getFullYear() === now.getFullYear() &&
-    timestamp.getMonth() === now.getMonth() &&
-    timestamp.getDate() === now.getDate();
-  const time = timestamp.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-  const formatted = isToday ? time : `${timestamp.toLocaleDateString()} · ${time}`;
+  const formatted = formatMessageMetaTimestamp(item.createdAt);
   const expiresIn = isDm && typeof item.expiresAt === 'number' ? item.expiresAt - nowSec : null;
 
   const isOutgoingByUserSub =

--- a/frontend/src/features/guest/parsers.ts
+++ b/frontend/src/features/guest/parsers.ts
@@ -1,19 +1,12 @@
 import type { MediaItem, MediaKind } from '../../types/media';
 import type { ReactionMap, ReactionUsersMap } from '../../types/reactions';
+import { formatMessageMetaTimestamp } from '../../utils/chatDates';
 import type { GuestChatEnvelope, GuestMessage } from './types';
 
 export function formatGuestTimestamp(ms: number): string {
   const t = Number(ms);
   if (!Number.isFinite(t) || t <= 0) return '';
-  const d = new Date(t);
-  const time = d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-  const now = new Date();
-  const isToday =
-    d.getFullYear() === now.getFullYear() &&
-    d.getMonth() === now.getMonth() &&
-    d.getDate() === now.getDate();
-  if (isToday) return time;
-  return `${d.toLocaleDateString()} ${time}`;
+  return formatMessageMetaTimestamp(t);
 }
 
 export function normalizeGuestReactions(raw: unknown): ReactionMap | undefined {

--- a/frontend/src/utils/__tests__/cdn.test.ts
+++ b/frontend/src/utils/__tests__/cdn.test.ts
@@ -1,0 +1,27 @@
+import { toCdnUrl } from '../cdn';
+
+describe('toCdnUrl', () => {
+  it('joins base + path', () => {
+    expect(toCdnUrl('https://cdn.example.com', 'uploads/a.png')).toBe(
+      'https://cdn.example.com/uploads/a.png',
+    );
+  });
+
+  it('handles extra slashes', () => {
+    expect(toCdnUrl('https://cdn.example.com/', '/uploads/a.png')).toBe(
+      'https://cdn.example.com/uploads/a.png',
+    );
+  });
+
+  it('returns empty string when base is empty', () => {
+    expect(toCdnUrl('', 'uploads/a.png')).toBe('');
+  });
+
+  it('returns empty string when path is empty', () => {
+    expect(toCdnUrl('https://cdn.example.com', '')).toBe('');
+  });
+
+  it('returns empty string for invalid base URL', () => {
+    expect(toCdnUrl('not-a-url', 'uploads/a.png')).toBe('');
+  });
+});

--- a/frontend/src/utils/__tests__/chatDates.test.ts
+++ b/frontend/src/utils/__tests__/chatDates.test.ts
@@ -1,0 +1,57 @@
+import { formatChatActivityDate, formatMessageMetaTimestamp } from '../chatDates';
+
+describe('chatDates', () => {
+  describe('formatMessageMetaTimestamp', () => {
+    it('returns time only for today', () => {
+      const now = new Date(2026, 0, 2, 12, 0, 0).getTime();
+      const ts = new Date(2026, 0, 2, 8, 30, 0).getTime();
+
+      const out = formatMessageMetaTimestamp(ts, now);
+
+      // "HH:MM" (locale-dependent AM/PM), but should not include our separator.
+      expect(out.includes(' · ')).toBe(false);
+      expect(out.length).toBeGreaterThan(0);
+    });
+
+    it('includes weekday for last 6 days', () => {
+      const now = new Date(2026, 0, 7, 12, 0, 0).getTime(); // Tue/Wed depending, but fixed
+      const ts = new Date(2026, 0, 6, 8, 30, 0).getTime(); // 1 day ago
+
+      const out = formatMessageMetaTimestamp(ts, now);
+      expect(out.split(' · ').length).toBe(2); // "Mon · TIME"
+    });
+
+    it('includes month+day (no year) for older than 6 days but < 1 year', () => {
+      const now = new Date(2026, 0, 20, 12, 0, 0).getTime();
+      const ts = new Date(2026, 0, 1, 8, 30, 0).getTime(); // 19 days ago
+
+      const out = formatMessageMetaTimestamp(ts, now);
+      // "Jan 1 · TIME"
+      expect(out.split(' · ').length).toBe(2);
+      expect(out.includes("'")).toBe(false);
+    });
+
+    it('includes two-digit year for >= 1 year', () => {
+      const now = new Date(2026, 0, 2, 12, 0, 0).getTime();
+      const ts = new Date(2024, 11, 31, 8, 30, 0).getTime();
+
+      const out = formatMessageMetaTimestamp(ts, now);
+      expect(out.includes(" '24 · ")).toBe(true);
+    });
+  });
+
+  describe('formatChatActivityDate', () => {
+    it('returns weekday for last 6 days', () => {
+      const now = new Date(2026, 0, 7, 12, 0, 0).getTime();
+      const ts = new Date(2026, 0, 6, 8, 30, 0).getTime();
+      expect(formatChatActivityDate(ts, now).length).toBeGreaterThan(0);
+      expect(formatChatActivityDate(ts, now).includes("'")).toBe(false);
+    });
+
+    it("returns month+day+'yy for >= 1 year", () => {
+      const now = new Date(2026, 0, 2, 12, 0, 0).getTime();
+      const ts = new Date(2024, 11, 31, 8, 30, 0).getTime();
+      expect(formatChatActivityDate(ts, now).includes("'24")).toBe(true);
+    });
+  });
+});

--- a/frontend/src/utils/__tests__/formatRemaining.test.ts
+++ b/frontend/src/utils/__tests__/formatRemaining.test.ts
@@ -1,0 +1,29 @@
+import { formatRemaining } from '../formatRemaining';
+
+describe('formatRemaining', () => {
+  it('returns 0s for empty/invalid/non-positive inputs', () => {
+    expect(formatRemaining(0)).toBe('0s');
+    expect(formatRemaining(-1)).toBe('0s');
+    expect(formatRemaining(NaN)).toBe('0s');
+  });
+
+  it('formats seconds under a minute', () => {
+    expect(formatRemaining(1)).toBe('1s');
+    expect(formatRemaining(59)).toBe('59s');
+  });
+
+  it('formats minutes', () => {
+    expect(formatRemaining(60)).toBe('1m');
+    expect(formatRemaining(61)).toBe('1m');
+  });
+
+  it('formats hours (and optionally minutes)', () => {
+    expect(formatRemaining(3600)).toBe('1h');
+    expect(formatRemaining(3660)).toBe('1h 1m');
+  });
+
+  it('formats days (and optionally hours)', () => {
+    expect(formatRemaining(86400)).toBe('1d');
+    expect(formatRemaining(90000)).toBe('1d 1h');
+  });
+});

--- a/frontend/src/utils/__tests__/ids.test.ts
+++ b/frontend/src/utils/__tests__/ids.test.ts
@@ -1,0 +1,46 @@
+import { randomBase36Suffix, timestampId } from '../ids';
+
+describe('ids', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('randomBase36Suffix', () => {
+    it('is deterministic when Math.random is mocked', () => {
+      jest.spyOn(Math, 'random').mockReturnValue(0.123456789);
+
+      const suf = randomBase36Suffix();
+
+      expect(suf).toEqual(expect.any(String));
+      expect(suf.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('timestampId', () => {
+    it('uses the provided timestamp (floored) and no prefix', () => {
+      jest.spyOn(Math, 'random').mockReturnValue(0.5);
+
+      const id = timestampId(1700.9);
+
+      expect(id.startsWith('1700-')).toBe(true);
+    });
+
+    it('uses Date.now() when ts is not finite', () => {
+      jest.spyOn(Date, 'now').mockReturnValue(424242);
+      jest.spyOn(Math, 'random').mockReturnValue(0.5);
+
+      const id = timestampId(Number.NaN);
+
+      expect(id.startsWith('424242-')).toBe(true);
+    });
+
+    it('includes prefix when provided', () => {
+      jest.spyOn(Date, 'now').mockReturnValue(10);
+      jest.spyOn(Math, 'random').mockReturnValue(0.5);
+
+      const id = timestampId(Number.NaN, 'msg');
+
+      expect(id.startsWith('msg-10-')).toBe(true);
+    });
+  });
+});

--- a/frontend/src/utils/__tests__/listMerge.test.ts
+++ b/frontend/src/utils/__tests__/listMerge.test.ts
@@ -1,0 +1,45 @@
+import { appendUniqueById, dedupeById, prependUniqueById } from '../listMerge';
+
+describe('listMerge', () => {
+  describe('dedupeById', () => {
+    it('keeps first occurrence and preserves order', () => {
+      const items = [{ id: 'a' }, { id: 'b' }, { id: 'a' }, { id: 'c' }];
+      expect(dedupeById(items)).toEqual([{ id: 'a' }, { id: 'b' }, { id: 'c' }]);
+    });
+
+    it('skips items with empty id', () => {
+      const items = [{ id: 'a' }, { id: 'b' }, { id: '' }, { id: 'c' }];
+      expect(dedupeById(items)).toEqual([{ id: 'a' }, { id: 'b' }, { id: 'c' }]);
+    });
+  });
+
+  describe('appendUniqueById', () => {
+    it('appends only ids not already in prev', () => {
+      const prev = [{ id: 'a' }, { id: 'b' }];
+      const incoming = [{ id: 'b' }, { id: 'c' }];
+      expect(appendUniqueById(prev, incoming)).toEqual({
+        merged: [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
+        appendedCount: 1,
+      });
+    });
+    it('does not mutate prev', () => {
+      const prev = [{ id: 'a' }, { id: 'b' }];
+      const incoming = [{ id: 'b' }, { id: 'c' }];
+      appendUniqueById(prev, incoming);
+      expect(prev).toEqual([{ id: 'a' }, { id: 'b' }]);
+    });
+    it('empty incoming returns new array and appendedCount is 0', () => {
+      const prev = [{ id: 'a' }, { id: 'b' }];
+      const incoming: { id: string }[] = [];
+      const result = appendUniqueById(prev, incoming);
+      expect(result.merged).not.toBe(prev);
+    });
+  });
+  describe('prependUniqueById', () => {
+    it('prepends only new ids', () => {
+      const prev = [{ id: 'a' }, { id: 'b' }];
+      const incoming = [{ id: 'c' }, { id: 'b' }];
+      expect(prependUniqueById(incoming, prev)).toEqual([{ id: 'c' }, { id: 'a' }, { id: 'b' }]);
+    });
+  });
+});

--- a/frontend/src/utils/__tests__/mediaSizing.test.ts
+++ b/frontend/src/utils/__tests__/mediaSizing.test.ts
@@ -1,0 +1,50 @@
+import { calcCappedMediaSize } from '../mediaSizing';
+
+describe('calcCappedMediaSize', () => {
+  it('caps height to maxHeight using defaults (aspect=1)', () => {
+    // With defaults: frac=0.86, maxHeight=240, minMaxWidth=220, rounding=floor
+    // availableWidth=1000 => maxW=max(220, floor(1000*0.86)=860)=860
+    // aspect=1 => initial h=floor(860/1)=860 which exceeds 240 => cap to 240
+    // then w=floor(240*1)=240
+    expect(calcCappedMediaSize({ availableWidth: 1000, aspect: 1 })).toEqual({ w: 240, h: 240 });
+  });
+
+  it('caps height and recomputes width for a wide aspect (16:9)', () => {
+    // maxW=860; initial h=floor(860 / (16/9))=483 => cap to 240
+    // w=floor(240*(16/9))=426
+    expect(calcCappedMediaSize({ availableWidth: 1000, aspect: 16 / 9 })).toEqual({
+      w: 426,
+      h: 240,
+    });
+  });
+
+  it('uses minWWhenCapped to prevent width from becoming too small after capping', () => {
+    // With a tall aspect, width after cap would be small; minWWhenCapped forces a minimum.
+    // maxW=860; cap height to 240
+    // w2=floor(240*(9/16))=135; minWWhenCapped=220 => w2 becomes 220; w=min(860,220)=220
+    expect(
+      calcCappedMediaSize({ availableWidth: 1000, aspect: 9 / 16, minWWhenCapped: 220 }),
+    ).toEqual({ w: 220, h: 240 });
+  });
+
+  it('respects minHInitial (forces an initial minimum height before any capping)', () => {
+    // availableWidth=300 => maxW=max(220, floor(300*0.86)=258)=258
+    // aspect=2 => h=floor(258/2)=129
+    // minHInitial=200 => h becomes 200 (still <= maxHeight=240 so no cap)
+    expect(calcCappedMediaSize({ availableWidth: 300, aspect: 2, minHInitial: 200 })).toEqual({
+      w: 258,
+      h: 200,
+    });
+  });
+
+  it('rounding=round changes the computed height compared to floor', () => {
+    // Choose availableWidth so maxW becomes 221:
+    // floor(257*0.86)=221; maxW=max(220,221)=221
+    // aspect=2 => w/a = 110.5 => floor => 110, round => 111
+    const floorSize = calcCappedMediaSize({ availableWidth: 257, aspect: 2, rounding: 'floor' });
+    const roundSize = calcCappedMediaSize({ availableWidth: 257, aspect: 2, rounding: 'round' });
+
+    expect(floorSize).toEqual({ w: 221, h: 110 });
+    expect(roundSize).toEqual({ w: 221, h: 111 });
+  });
+});

--- a/frontend/src/utils/__tests__/resolveMediaUrl.test.ts
+++ b/frontend/src/utils/__tests__/resolveMediaUrl.test.ts
@@ -1,0 +1,72 @@
+import { resolveMediaPathUrls, resolveMediaUrlWithFallback } from '../resolveMediaUrl';
+
+describe('resolveMediaUrl', () => {
+  describe('resolveMediaUrlWithFallback', () => {
+    it('returns preferred when it resolves (does not try fallback)', async () => {
+      const resolvePathUrl = jest.fn(async (path: string) =>
+        path === 'preferred' ? 'https://cdn.example.com/p' : null,
+      );
+
+      const url = await resolveMediaUrlWithFallback(resolvePathUrl, 'preferred', 'fallback');
+
+      expect(url).toBe('https://cdn.example.com/p');
+      expect(resolvePathUrl).toHaveBeenCalledTimes(1);
+      expect(resolvePathUrl).toHaveBeenCalledWith('preferred');
+    });
+
+    it('falls back when preferred fails', async () => {
+      const resolvePathUrl = jest.fn(async (path: string) =>
+        path === 'fallback' ? 'https://cdn.example.com/f' : null,
+      );
+
+      const url = await resolveMediaUrlWithFallback(resolvePathUrl, 'preferred', 'fallback');
+
+      expect(url).toBe('https://cdn.example.com/f');
+      expect(resolvePathUrl).toHaveBeenCalledTimes(2);
+      expect(resolvePathUrl).toHaveBeenNthCalledWith(1, 'preferred');
+      expect(resolvePathUrl).toHaveBeenNthCalledWith(2, 'fallback');
+    });
+
+    it('trims preferred and fallback paths', async () => {
+      const resolvePathUrl = jest.fn(async (path: string) => `URL:${path}`);
+
+      const url = await resolveMediaUrlWithFallback(
+        resolvePathUrl,
+        '  preferred  ',
+        '  fallback  ',
+      );
+
+      expect(url).toBe('URL:preferred');
+      expect(resolvePathUrl).toHaveBeenCalledWith('preferred');
+    });
+
+    it('does not call resolver twice when fallback equals preferred', async () => {
+      const resolvePathUrl = jest.fn(async (_path: string) => null);
+
+      const url = await resolveMediaUrlWithFallback(resolvePathUrl, 'same', 'same');
+
+      expect(url).toBeNull();
+      expect(resolvePathUrl).toHaveBeenCalledTimes(1);
+      expect(resolvePathUrl).toHaveBeenCalledWith('same');
+    });
+  });
+
+  describe('resolveMediaPathUrls', () => {
+    it('returns same-length array; null for empty/missing paths', async () => {
+      const resolvePathUrl = jest.fn(async (path: string) => `URL:${path}`);
+
+      const urls = await resolveMediaPathUrls(resolvePathUrl, [
+        { path: 'a' },
+        { path: '   ' },
+        { path: null },
+        {},
+        { path: 'b' },
+      ]);
+
+      expect(urls).toEqual(['URL:a', null, null, null, 'URL:b']);
+      expect(resolvePathUrl).toHaveBeenCalledTimes(2);
+      expect(resolvePathUrl).toHaveBeenNthCalledWith(1, 'a');
+      expect(resolvePathUrl).toHaveBeenNthCalledWith(2, 'b');
+    });
+  });
+});

--- a/frontend/src/utils/__tests__/seenLabels.test.ts
+++ b/frontend/src/utils/__tests__/seenLabels.test.ts
@@ -1,0 +1,60 @@
+import { formatSeenLabel, getSeenLabelForCreatedAt } from '../seenLabels';
+
+describe('seenLabels', () => {
+  describe('formatSeenLabel', () => {
+    it('returns "Seen" for invalid or non-positive timestamps', () => {
+      expect(formatSeenLabel(0, new Date())).toBe('Seen');
+      expect(formatSeenLabel(-1, new Date())).toBe('Seen');
+      expect(formatSeenLabel(Number.NaN, new Date())).toBe('Seen');
+    });
+
+    it('formats as "Seen · HH:MM" when readAt is today', () => {
+      const now = new Date(2026, 0, 2, 12, 0, 0); // Jan 2, 2026 local
+      const readAtSec = Math.floor(now.getTime() / 1000);
+
+      const label = formatSeenLabel(readAtSec, now);
+
+      expect(label.startsWith('Seen · ')).toBe(true);
+      expect(label.split(' · ').length).toBe(2); // "Seen · TIME"
+    });
+
+    it('formats as "Seen · Mon · HH:MM" when readAt is within the last 6 days', () => {
+      const now = new Date(2026, 0, 2, 12, 0, 0);
+      const yesterday = new Date(2026, 0, 1, 12, 0, 0);
+      const readAtSec = Math.floor(yesterday.getTime() / 1000);
+
+      const label = formatSeenLabel(readAtSec, now);
+
+      // Expect two separators: "Seen · WEEKDAY · TIME"
+      expect(label.split(' · ').length).toBe(3);
+      expect(label.startsWith('Seen · ')).toBe(true);
+    });
+
+    it('includes a two-digit year for timestamps >= 1 year ago (e.g. "\\\'25")', () => {
+      const now = new Date(2026, 0, 2, 12, 0, 0);
+      const older = new Date(2024, 11, 31, 12, 0, 0);
+      const readAtSec = Math.floor(older.getTime() / 1000);
+
+      const label = formatSeenLabel(readAtSec, now);
+
+      expect(label.includes(" '24 · ")).toBe(true);
+    });
+  });
+
+  describe('getSeenLabelForCreatedAt', () => {
+    it('returns null when the map has no valid seen time for that createdAt', () => {
+      expect(getSeenLabelForCreatedAt({}, 123)).toBeNull();
+      expect(getSeenLabelForCreatedAt({ '123': 0 }, 123)).toBeNull();
+    });
+
+    it('returns a formatted label when a valid seen time exists', () => {
+      const now = new Date(2026, 0, 2, 12, 0, 0);
+      const readAtSec = Math.floor(now.getTime() / 1000);
+
+      const label = getSeenLabelForCreatedAt({ '1000': readAtSec }, 1000);
+
+      expect(label).not.toBeNull();
+      expect(label?.startsWith('Seen')).toBe(true);
+    });
+  });
+});

--- a/frontend/src/utils/chatDates.ts
+++ b/frontend/src/utils/chatDates.ts
@@ -13,17 +13,77 @@ function formatParts(
   return { month: get('month'), day: get('day'), year: get('year'), weekday: get('weekday') };
 }
 
+function formatTime(d: Date): string {
+  // Use locale default for AM/PM vs 24h, but lock the fields we care about.
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+function twoDigitYear(d: Date): string {
+  const y = d.getFullYear();
+  const yy = String(Math.abs(y) % 100).padStart(2, '0');
+  return `'${yy}`;
+}
+
+function diffLocalDays(now: Date, then: Date): number {
+  return Math.floor((startOfLocalDayMs(now) - startOfLocalDayMs(then)) / DAY_MS);
+}
+
+export type RelativeDateBucket = 'today' | 'last6days' | 'older' | 'olderThanYear';
+
+export function getRelativeDateBucket(
+  epochMs: number,
+  nowMs: number = Date.now(),
+): RelativeDateBucket {
+  const t = Number(epochMs || 0);
+  if (!Number.isFinite(t) || t <= 0) return 'older';
+  const d = new Date(t);
+  const now = new Date(nowMs);
+  const days = diffLocalDays(now, d);
+  if (days <= 0) return 'today';
+  if (days <= 6) return 'last6days';
+  if (days >= 365) return 'olderThanYear';
+  return 'older';
+}
+
+/**
+ * Message/receipt timestamp formatting:
+ * - today: "HH:MM"
+ * - 1-6 days ago: "Mon · HH:MM"
+ * - older: "Feb 6 · HH:MM" (no year)
+ * - >= 1 year: "Feb 6 '25 · HH:MM"
+ */
+export function formatMessageMetaTimestamp(epochMs: number, nowMs: number = Date.now()): string {
+  const t = Number(epochMs || 0);
+  if (!Number.isFinite(t) || t <= 0) return '';
+  const d = new Date(t);
+  const now = new Date(nowMs);
+  const days = diffLocalDays(now, d);
+
+  const time = formatTime(d);
+  if (days <= 0) return time;
+
+  if (days <= 6) {
+    const weekday = new Intl.DateTimeFormat('en-US', { weekday: 'short' }).format(d);
+    return `${weekday} · ${time}`;
+  }
+
+  const { month, day } = formatParts(d, { month: 'short', day: 'numeric' });
+  const md = [month, day].filter(Boolean).join(' ');
+  if (days >= 365) return `${md} ${twoDigitYear(d)} · ${time}`;
+  return `${md} · ${time}`;
+}
+
 // Chats list date label:
 // - last 6 days: "Mon", "Tue", ...
 // - older: "Feb 6"
-// - over a year: "Dec 15 2024"
+// - over a year: "Dec 15 '24"
 export function formatChatActivityDate(epochMs: number, nowMs: number = Date.now()): string {
   const t = Number(epochMs || 0);
   if (!Number.isFinite(t) || t <= 0) return '';
 
   const d = new Date(t);
   const now = new Date(nowMs);
-  const diffDays = Math.floor((startOfLocalDayMs(now) - startOfLocalDayMs(d)) / DAY_MS);
+  const diffDays = diffLocalDays(now, d);
 
   if (diffDays <= 6) {
     // Short weekday (no punctuation)
@@ -32,12 +92,9 @@ export function formatChatActivityDate(epochMs: number, nowMs: number = Date.now
 
   const includeYear = diffDays >= 365;
   if (includeYear) {
-    const { month, day, year } = formatParts(d, {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    });
-    return [month, day, year].filter(Boolean).join(' ');
+    const { month, day } = formatParts(d, { month: 'short', day: 'numeric' });
+    const md = [month, day].filter(Boolean).join(' ');
+    return [md, twoDigitYear(d)].filter(Boolean).join(' ');
   }
 
   const { month, day } = formatParts(d, { month: 'short', day: 'numeric' });

--- a/frontend/src/utils/seenLabels.ts
+++ b/frontend/src/utils/seenLabels.ts
@@ -1,13 +1,11 @@
+import { formatMessageMetaTimestamp } from './chatDates';
+
 export function formatSeenLabel(readAtSec: number, now: Date = new Date()): string {
   const sec = Number(readAtSec || 0);
   if (!Number.isFinite(sec) || sec <= 0) return 'Seen';
   const dt = new Date(sec * 1000);
-  const isToday =
-    dt.getFullYear() === now.getFullYear() &&
-    dt.getMonth() === now.getMonth() &&
-    dt.getDate() === now.getDate();
-  const time = dt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-  return isToday ? `Seen · ${time}` : `Seen · ${dt.toLocaleDateString()} · ${time}`;
+  const stamp = formatMessageMetaTimestamp(dt.getTime(), now.getTime());
+  return stamp ? `Seen · ${stamp}` : 'Seen';
 }
 
 export function getSeenLabelForCreatedAt(


### PR DESCRIPTION
Formatting Seen and Message meta timestamps so:
* Same day = No Date, just time
* Yesterday to 6 days ago = 3 letter day 
* Older but same year = Date in 3 letter month, Day date
* Over 1 year includes a 'XX 2 digit year format (since app is obviously made after 2000)

Initial Jest Unit tests wired

Implement testing into Continuous Integration 