### PR TITLE
Persistence and UI cleanup

### DIFF
--- a/frontend/src/features/appShell/hooks/useLastConversation.ts
+++ b/frontend/src/features/appShell/hooks/useLastConversation.ts
@@ -1,0 +1,173 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as React from 'react';
+
+import type { ServerConversation, UnreadDmMap } from './useChatsInboxData';
+
+function isValidConversationId(v: string): boolean {
+  if (!v) return false;
+  if (v === 'global') return true;
+  return v.startsWith('ch#') || v.startsWith('dm#') || v.startsWith('gdm#');
+}
+
+function getDeviceStorageKey(): string {
+  // Device-scoped fallback so we can restore immediately even before user attrs rehydrate.
+  return 'ui:lastConversationId:device';
+}
+
+function getUserStorageKey(userSub: string | null | undefined): string | null {
+  const u = typeof userSub === 'string' ? userSub.trim() : '';
+  if (!u) return null;
+  return `ui:lastConversationId:${u}`;
+}
+
+function bestEffortPeerTitle(opts: {
+  conversationId: string;
+  serverConversations: ServerConversation[];
+  unreadDmMap: UnreadDmMap;
+}): string {
+  const { conversationId, serverConversations, unreadDmMap } = opts;
+  const server = serverConversations.find((c) => c.conversationId === conversationId);
+  const cached = unreadDmMap[conversationId];
+  const kind =
+    (typeof server?.conversationKind === 'string' ? server.conversationKind : undefined) ||
+    (conversationId.startsWith('gdm#')
+      ? 'group'
+      : conversationId.startsWith('dm#')
+        ? 'dm'
+        : undefined);
+  const serverTitle = server?.peerDisplayName != null ? String(server.peerDisplayName).trim() : '';
+  const cachedTitle = cached?.user != null ? String(cached.user).trim() : '';
+  const fallbackTitle = kind === 'group' ? 'Group DM' : 'Direct Message';
+  return serverTitle || cachedTitle || fallbackTitle;
+}
+
+async function readCachedConversationTitle(conversationId: string): Promise<string> {
+  const convId = String(conversationId || '').trim();
+  if (!convId) return '';
+
+  // 1) conversations cache (best for groups; also includes dm peer names)
+  try {
+    const raw = await AsyncStorage.getItem('conversations:cache:v1');
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      const convos = Array.isArray(parsed?.conversations) ? parsed.conversations : [];
+      const hit = convos.find((c: unknown) => {
+        const rec = typeof c === 'object' && c != null ? (c as Record<string, unknown>) : {};
+        return String(rec.conversationId || '').trim() === convId;
+      });
+      const rec = typeof hit === 'object' && hit != null ? (hit as Record<string, unknown>) : {};
+      const t = typeof rec.peerDisplayName === 'string' ? String(rec.peerDisplayName).trim() : '';
+      if (t) return t;
+    }
+  } catch {
+    // ignore
+  }
+
+  // 2) dm threads cache (local-only inbox)
+  try {
+    const raw = await AsyncStorage.getItem('dm:threads:v1');
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      const info =
+        parsed && typeof parsed === 'object'
+          ? (parsed as Record<string, { peer?: unknown }>)[convId]
+          : undefined;
+      const t = typeof info?.peer === 'string' ? String(info.peer).trim() : '';
+      if (t) return t;
+    }
+  } catch {
+    // ignore
+  }
+
+  return '';
+}
+
+export function useLastConversation({
+  userSub,
+  conversationId,
+  setConversationId,
+  setPeer,
+  serverConversations,
+  unreadDmMap,
+}: {
+  userSub: string | null;
+  conversationId: string;
+  setConversationId: React.Dispatch<React.SetStateAction<string>>;
+  setPeer: React.Dispatch<React.SetStateAction<string | null>>;
+  serverConversations: ServerConversation[];
+  unreadDmMap: UnreadDmMap;
+}): { conversationRestoreDone: boolean } {
+  const [conversationRestoreDone, setConversationRestoreDone] = React.useState<boolean>(false);
+  const latestConversationIdRef = React.useRef<string>(conversationId);
+
+  React.useEffect(() => {
+    latestConversationIdRef.current = conversationId;
+  }, [conversationId]);
+
+  // Restore last visited conversation on boot (channels + DMs).
+  React.useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const userKey = getUserStorageKey(userSub);
+        const raw =
+          (userKey ? await AsyncStorage.getItem(userKey) : null) ||
+          (await AsyncStorage.getItem(getDeviceStorageKey()));
+        const v = typeof raw === 'string' ? raw.trim() : '';
+        if (!mounted) return;
+        if (!isValidConversationId(v)) return;
+
+        const current = String(latestConversationIdRef.current || '').trim() || 'global';
+        // If something already put us into a DM (e.g. opened-from-notification), don't override it.
+        if (current.startsWith('dm#') || current.startsWith('gdm#')) return;
+
+        // Otherwise, prefer restoring the last conversation (including DMs) over default channel.
+        setConversationId(() => v);
+
+        if (v.startsWith('dm#') || v.startsWith('gdm#')) {
+          const immediate = bestEffortPeerTitle({
+            conversationId: v,
+            serverConversations,
+            unreadDmMap,
+          });
+          if (immediate && immediate !== 'Direct Message' && immediate !== 'Group DM') {
+            setPeer(() => immediate);
+          } else {
+            const cachedTitle = await readCachedConversationTitle(v);
+            const fallback = v.startsWith('gdm#') ? 'Group DM' : 'Direct Message';
+            setPeer(() => cachedTitle || immediate || fallback);
+          }
+        } else {
+          setPeer(() => null);
+        }
+      } catch {
+        // ignore
+      } finally {
+        if (mounted) setConversationRestoreDone(true);
+      }
+    })();
+    // Important: only re-run when identity changes (so switching accounts restores that account's last view).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userSub]);
+
+  // Persist last visited conversation (best-effort).
+  React.useEffect(() => {
+    const v = String(conversationId || '').trim();
+    if (!isValidConversationId(v)) return;
+    (async () => {
+      try {
+        await AsyncStorage.setItem(getDeviceStorageKey(), v);
+      } catch {
+        // ignore
+      }
+      try {
+        const userKey = getUserStorageKey(userSub);
+        if (userKey) await AsyncStorage.setItem(userKey, v);
+      } catch {
+        // ignore
+      }
+    })();
+  }, [conversationId, userSub]);
+
+  return { conversationRestoreDone };
+}

--- a/frontend/src/features/chat/buildChatScreenMainProps.ts
+++ b/frontend/src/features/chat/buildChatScreenMainProps.ts
@@ -21,6 +21,7 @@ export function buildChatScreenMainProps(deps: {
   myUserId: HeaderProps['myUserId'];
   avatarProfileBySub: HeaderProps['avatarProfileBySub'];
   avatarUrlByPath: HeaderProps['avatarUrlByPath'];
+  myAvatarOverride: HeaderProps['myAvatarOverride'];
   isConnecting: HeaderProps['isConnecting'];
   isConnected: HeaderProps['isConnected'];
   isEncryptedChat: HeaderProps['isEncryptedChat'];
@@ -116,6 +117,7 @@ export function buildChatScreenMainProps(deps: {
       myUserId: deps.myUserId,
       avatarProfileBySub: deps.avatarProfileBySub,
       avatarUrlByPath: deps.avatarUrlByPath,
+      myAvatarOverride: deps.myAvatarOverride,
       isConnecting: deps.isConnecting,
       isConnected: deps.isConnected,
       isEncryptedChat: deps.isEncryptedChat,

--- a/frontend/src/features/chat/components/ChatHeaderStatusRow.tsx
+++ b/frontend/src/features/chat/components/ChatHeaderStatusRow.tsx
@@ -1,24 +1,13 @@
 import { MaterialIcons } from '@expo/vector-icons';
 import React from 'react';
-import { Pressable, Text, View } from 'react-native';
+import { Pressable, View } from 'react-native';
 
-import { AnimatedDots } from '../../../components/AnimatedDots';
-import { AvatarBubble } from '../../../components/AvatarBubble';
-import type { PublicAvatarProfileLite } from '../../../hooks/usePublicAvatarProfiles';
 import type { ChatScreenStyles } from '../../../screens/ChatScreen.styles';
 import { APP_COLORS } from '../../../theme/colors';
 
 type Props = {
   styles: ChatScreenStyles;
   isDark: boolean;
-  displayName: string;
-
-  myUserId: string | null | undefined;
-  avatarProfileBySub: Record<string, PublicAvatarProfileLite>;
-  avatarUrlByPath: Record<string, string>;
-
-  isConnecting: boolean;
-  isConnected: boolean;
 
   showCaret: boolean;
   caretExpanded: boolean;
@@ -29,83 +18,31 @@ type Props = {
 export function ChatHeaderStatusRow({
   styles,
   isDark,
-  displayName,
-  myUserId,
-  avatarProfileBySub,
-  avatarUrlByPath,
-  isConnecting,
-  isConnected,
   showCaret,
   caretExpanded,
   caretA11yLabel,
   onPressCaret,
 }: Props) {
-  const myProf = myUserId ? avatarProfileBySub[String(myUserId)] : undefined;
-  const myAvatarImageUri = myProf?.avatarImagePath
-    ? avatarUrlByPath[String(myProf.avatarImagePath)]
-    : undefined;
-
   return (
     <View style={styles.headerSubRow}>
-      <View style={styles.welcomeRow}>
-        <AvatarBubble
-          size={34}
-          seed={String(myUserId || displayName || 'me')}
-          label={displayName || 'me'}
-          backgroundColor={myProf?.avatarBgColor}
-          textColor={myProf?.avatarTextColor}
-          imageUri={myAvatarImageUri}
-          imageBgColor={isDark ? APP_COLORS.dark.bg.header : APP_COLORS.light.bg.surface2}
-          style={styles.welcomeAvatar}
-        />
-        <Text
-          style={[
-            styles.welcomeText,
-            isDark ? styles.welcomeTextDark : null,
-            styles.welcomeTextFlex,
-          ]}
-          numberOfLines={1}
-          ellipsizeMode="tail"
-        >
-          {`Welcome ${displayName}!`}
-        </Text>
-        <View style={styles.welcomeStatusRow}>
-          <Text
-            style={[
-              styles.welcomeStatusText,
-              isDark ? styles.statusTextDark : null,
-              !isConnecting ? (isConnected ? styles.ok : styles.err) : null,
-            ]}
-            numberOfLines={1}
+      <View style={{ flex: 1 }} />
+      {/* Keep this row visually tight to the bottom of the header (no extra top offset). */}
+      <View style={[styles.welcomeStatusRow, { marginTop: 0 }]}>
+        {showCaret ? (
+          <Pressable
+            style={({ pressed }) => [styles.dmSettingsCaretBtn, pressed ? { opacity: 0.65 } : null]}
+            onPress={onPressCaret}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            accessibilityRole="button"
+            accessibilityLabel={caretA11yLabel}
           >
-            {isConnecting ? 'Connecting' : isConnected ? 'Connected' : 'Disconnected'}
-          </Text>
-          {isConnecting ? (
-            <AnimatedDots
-              // Don't read colors off StyleSheet objects (can be numeric in prod).
-              color={isDark ? APP_COLORS.dark.text.muted : APP_COLORS.light.text.muted}
-              size={16}
+            <MaterialIcons
+              name={caretExpanded ? 'keyboard-arrow-up' : 'keyboard-arrow-down'}
+              size={18}
+              color={isDark ? APP_COLORS.dark.text.secondary : APP_COLORS.light.text.secondary}
             />
-          ) : null}
-          {showCaret ? (
-            <Pressable
-              style={({ pressed }) => [
-                styles.dmSettingsCaretBtn,
-                pressed ? { opacity: 0.65 } : null,
-              ]}
-              onPress={onPressCaret}
-              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-              accessibilityRole="button"
-              accessibilityLabel={caretA11yLabel}
-            >
-              <MaterialIcons
-                name={caretExpanded ? 'keyboard-arrow-up' : 'keyboard-arrow-down'}
-                size={18}
-                color={isDark ? APP_COLORS.dark.text.secondary : APP_COLORS.light.text.secondary}
-              />
-            </Pressable>
-          ) : null}
-        </View>
+          </Pressable>
+        ) : null}
       </View>
     </View>
   );

--- a/frontend/src/features/chat/components/ChatHeaderTitleRow.tsx
+++ b/frontend/src/features/chat/components/ChatHeaderTitleRow.tsx
@@ -1,12 +1,25 @@
+import { FontAwesome } from '@expo/vector-icons';
 import React from 'react';
 import { Pressable, Text, View } from 'react-native';
 
+import { AnimatedDots } from '../../../components/AnimatedDots';
+import { AvatarBubble } from '../../../components/AvatarBubble';
+import { CDN_URL } from '../../../config/env';
+import type { PublicAvatarProfileLite } from '../../../hooks/usePublicAvatarProfiles';
 import type { ChatScreenStyles } from '../../../screens/ChatScreen.styles';
+import { APP_COLORS, PALETTE, withAlpha } from '../../../theme/colors';
+import { toCdnUrl } from '../../../utils/cdn';
 
 type Props = {
   styles: ChatScreenStyles;
   isDark: boolean;
-  title: string;
+  displayName: string;
+  myUserId: string | null | undefined;
+  avatarProfileBySub: Record<string, PublicAvatarProfileLite>;
+  avatarUrlByPath: Record<string, string>;
+  myAvatarOverride?: { bgColor?: string; textColor?: string; imagePath?: string } | null;
+  isConnecting: boolean;
+  isConnected: boolean;
   onPressSummarize: () => void;
   onPressAiHelper: () => void;
 };
@@ -14,19 +27,169 @@ type Props = {
 export function ChatHeaderTitleRow({
   styles,
   isDark,
-  title,
+  displayName,
+  myUserId,
+  avatarProfileBySub,
+  avatarUrlByPath,
+  myAvatarOverride,
+  isConnecting,
+  isConnected,
   onPressSummarize,
   onPressAiHelper,
 }: Props) {
+  const [welcomeRowWidth, setWelcomeRowWidth] = React.useState<number>(0);
+  const [avatarWidth, setAvatarWidth] = React.useState<number>(0);
+  const [statusWidth, setStatusWidth] = React.useState<number>(0);
+  const [welcomePrefixWidth, setWelcomePrefixWidth] = React.useState<number>(0);
+  const [welcomeNameWidth, setWelcomeNameWidth] = React.useState<number>(0);
+
+  // Use a non-breaking space so web doesn't visually collapse/trim the gap between
+  // "Welcome" and the username when rendered as separate <Text> nodes.
+  const welcomePrefixText = 'Welcome\u00A0';
+  const welcomeNameText = `${displayName}`;
+
+  const showWelcomePrefix = React.useMemo(() => {
+    // Only show "Welcome" if both pieces can fit without truncating the username.
+    if (
+      !(
+        welcomeRowWidth > 0 &&
+        avatarWidth >= 0 &&
+        statusWidth >= 0 &&
+        welcomePrefixWidth > 0 &&
+        welcomeNameWidth > 0
+      )
+    )
+      return false;
+
+    // `onLayout().width` does NOT include margins, so subtract the margins we apply in styles.
+    const avatarMarginRight = 8; // styles.welcomeAvatar.marginRight
+    const statusMarginLeft = 6; // styles.welcomeStatusRow.marginLeft
+    const availableTextWidth = Math.max(
+      0,
+      welcomeRowWidth - avatarWidth - avatarMarginRight - statusWidth - statusMarginLeft,
+    );
+
+    return welcomePrefixWidth + welcomeNameWidth <= availableTextWidth;
+  }, [welcomeRowWidth, avatarWidth, statusWidth, welcomePrefixWidth, welcomeNameWidth]);
+
+  const myProf = myUserId ? avatarProfileBySub[String(myUserId)] : undefined;
+  const o = myAvatarOverride && typeof myAvatarOverride === 'object' ? myAvatarOverride : null;
+  const oImagePath =
+    o && typeof o.imagePath === 'string' && o.imagePath.trim().length ? o.imagePath.trim() : '';
+  const myAvatarImageUri = myProf?.avatarImagePath
+    ? avatarUrlByPath[String(myProf.avatarImagePath)]
+    : undefined;
+  const overrideAvatarImageUri = oImagePath
+    ? avatarUrlByPath[oImagePath] || toCdnUrl(CDN_URL, oImagePath) || undefined
+    : undefined;
+
   return (
     <View style={styles.titleRow}>
-      <Text
-        style={[styles.title, isDark ? styles.titleDark : null]}
-        numberOfLines={1}
-        ellipsizeMode="tail"
+      <View
+        style={styles.welcomeRow}
+        onLayout={(e) => {
+          const w = e?.nativeEvent?.layout?.width;
+          if (typeof w === 'number' && Number.isFinite(w)) setWelcomeRowWidth(w);
+        }}
       >
-        {title}
-      </Text>
+        <View
+          style={styles.welcomeAvatar}
+          onLayout={(e) => {
+            const w = e?.nativeEvent?.layout?.width;
+            if (typeof w === 'number' && Number.isFinite(w)) setAvatarWidth(w);
+          }}
+        >
+          <AvatarBubble
+            size={34}
+            seed={String(myUserId || displayName || 'me')}
+            label={displayName || 'me'}
+            backgroundColor={myProf?.avatarBgColor || (o?.bgColor as string | undefined)}
+            textColor={myProf?.avatarTextColor || (o?.textColor as string | undefined)}
+            imageUri={myAvatarImageUri || overrideAvatarImageUri}
+            imageBgColor={isDark ? APP_COLORS.dark.bg.header : APP_COLORS.light.bg.surface2}
+          />
+        </View>
+        <View
+          style={styles.welcomeTextRow}
+          onLayout={(_e) => {
+            // Intentionally NOT used for show/hide logic; this container may size to content.
+            // Keeping this handler off avoids misleading calculations.
+          }}
+        >
+          {/* Hidden measurement row (absolute so it doesn't affect layout). */}
+          <View pointerEvents="none" style={styles.welcomeMeasureRow}>
+            <Text
+              style={[styles.welcomeText, isDark ? styles.welcomeTextDark : null]}
+              numberOfLines={1}
+              onLayout={(e) => {
+                const w = e?.nativeEvent?.layout?.width;
+                if (typeof w === 'number' && Number.isFinite(w)) setWelcomePrefixWidth(w);
+              }}
+            >
+              {welcomePrefixText}
+            </Text>
+            <Text
+              style={[styles.welcomeText, isDark ? styles.welcomeTextDark : null]}
+              numberOfLines={1}
+              onLayout={(e) => {
+                const w = e?.nativeEvent?.layout?.width;
+                if (typeof w === 'number' && Number.isFinite(w)) setWelcomeNameWidth(w);
+              }}
+            >
+              {welcomeNameText}
+            </Text>
+          </View>
+
+          {showWelcomePrefix ? (
+            <Text
+              style={[styles.welcomeText, isDark ? styles.welcomeTextDark : null]}
+              numberOfLines={1}
+            >
+              {welcomePrefixText}
+            </Text>
+          ) : null}
+
+          <Text
+            style={[
+              styles.welcomeText,
+              isDark ? styles.welcomeTextDark : null,
+              styles.welcomeNameFlex,
+            ]}
+            numberOfLines={1}
+            ellipsizeMode="tail"
+          >
+            {welcomeNameText}
+          </Text>
+        </View>
+        <View
+          style={styles.welcomeStatusRow}
+          onLayout={(e) => {
+            const w = e?.nativeEvent?.layout?.width;
+            if (typeof w === 'number' && Number.isFinite(w)) setStatusWidth(w);
+          }}
+        >
+          {isConnecting ? (
+            <AnimatedDots
+              color={isDark ? APP_COLORS.dark.text.muted : APP_COLORS.light.text.muted}
+              size={14}
+            />
+          ) : (
+            <FontAwesome
+              name={isConnected ? 'plug' : 'unlink'}
+              size={12}
+              color={
+                isConnected
+                  ? isDark
+                    ? withAlpha(APP_COLORS.dark.status.success, 0.55)
+                    : withAlpha(PALETTE.successText, 0.75)
+                  : isDark
+                    ? APP_COLORS.dark.status.errorText
+                    : APP_COLORS.light.status.errorText
+              }
+            />
+          )}
+        </View>
+      </View>
       <View style={styles.headerTools}>
         <Pressable
           style={[styles.summarizeBtn, isDark ? styles.summarizeBtnDark : null]}

--- a/frontend/src/features/chat/components/ChatScreenMain.tsx
+++ b/frontend/src/features/chat/components/ChatScreenMain.tsx
@@ -53,6 +53,7 @@ type ChatScreenMainProps = {
     myUserId: string | null;
     avatarProfileBySub: Record<string, PublicAvatarProfileLite>;
     avatarUrlByPath: Record<string, string>;
+    myAvatarOverride?: { bgColor?: string; textColor?: string; imagePath?: string } | null;
     isConnecting: boolean;
     isConnected: boolean;
 
@@ -236,19 +237,19 @@ export function ChatScreenMain({
           <ChatHeaderTitleRow
             styles={styles}
             isDark={isDark}
-            title={header.headerTitle}
+            displayName={header.displayName}
+            myUserId={header.myUserId}
+            avatarProfileBySub={header.avatarProfileBySub}
+            avatarUrlByPath={header.avatarUrlByPath}
+            myAvatarOverride={header.myAvatarOverride}
+            isConnecting={header.isConnecting}
+            isConnected={header.isConnected}
             onPressSummarize={header.onPressSummarize}
             onPressAiHelper={header.onPressAiHelper}
           />
           <ChatHeaderStatusRow
             styles={styles}
             isDark={isDark}
-            displayName={header.displayName}
-            myUserId={header.myUserId}
-            avatarProfileBySub={header.avatarProfileBySub}
-            avatarUrlByPath={header.avatarUrlByPath}
-            isConnecting={header.isConnecting}
-            isConnected={header.isConnected}
             showCaret={!!(header.isEncryptedChat || header.isChannel)}
             caretExpanded={
               !!(header.isEncryptedChat ? header.dmSettingsOpen : header.channelSettingsOpen)

--- a/frontend/src/features/chat/components/DmSettingsPanel.tsx
+++ b/frontend/src/features/chat/components/DmSettingsPanel.tsx
@@ -162,7 +162,13 @@ export function DmSettingsPanel({
                 ]}
                 onPress={onOpenTtlPicker}
               >
-                <Text style={[styles.ttlChipText, isDark ? styles.ttlChipTextDark : null]}>
+                <Text
+                  style={[
+                    styles.ttlChipText,
+                    isDark ? styles.ttlChipTextDark : null,
+                    String(ttlLabel).trim().toLowerCase() === 'off' ? styles.ttlChipTextOff : null,
+                  ]}
+                >
                   {ttlLabel}
                 </Text>
               </Pressable>

--- a/frontend/src/screens/ChatScreen.styles.ts
+++ b/frontend/src/screens/ChatScreen.styles.ts
@@ -21,7 +21,7 @@ export const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 10,
     // Keep the bottom tight so the message list starts closer to the header content.
-    paddingBottom: 4,
+    paddingBottom: 0,
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: APP_COLORS.light.border.subtle,
     backgroundColor: APP_COLORS.light.bg.header,
@@ -57,7 +57,18 @@ export const styles = StyleSheet.create({
     fontWeight: '700',
   },
   welcomeTextDark: { color: APP_COLORS.dark.text.secondary },
-  welcomeTextFlex: { flexGrow: 1, flexShrink: 1, minWidth: 0 },
+  // Split "Welcome " and "<username>!" so we can hide "Welcome" entirely when space is tight,
+  // keeping the username whole as long as possible, then truncating username only if needed.
+  welcomeTextRow: { flexDirection: 'row', alignItems: 'center', flexShrink: 1, minWidth: 0 },
+  welcomeMeasureRow: {
+    position: 'absolute',
+    opacity: 0,
+    left: 0,
+    top: 0,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  welcomeNameFlex: { flexShrink: 1, minWidth: 0 },
   welcomeRow: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -70,12 +81,13 @@ export const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 6,
+    marginLeft: 6,
     marginTop: 2,
     flexShrink: 0,
   },
   welcomeStatusText: { fontSize: 12, color: APP_COLORS.light.text.muted, fontWeight: '800' },
   headerSubRow: {
-    marginTop: 1,
+    marginTop: 0,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
@@ -181,12 +193,15 @@ export const styles = StyleSheet.create({
   miniToggleDisabled: { opacity: 0.6 },
   miniTogglePressed: { opacity: 0.85 },
   ttlChip: {
-    paddingHorizontal: 10,
-    paddingVertical: 6,
+    paddingHorizontal: 6,
+    paddingVertical: 2,
     borderRadius: 999,
     backgroundColor: PALETTE.paper200,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   ttlChipText: { fontSize: 12, color: PALETTE.slate870, fontWeight: '700' },
+  ttlChipTextOff: { marginTop: 1 },
   ttlChipDark: {
     backgroundColor: PALETTE.slate750,
   },
@@ -220,7 +235,7 @@ export const styles = StyleSheet.create({
   ttlOptionRadioSelected: { color: PALETTE.white },
   ttlOptionLabelDark: { color: PALETTE.white },
   summarizeBtn: {
-    paddingHorizontal: 12,
+    paddingHorizontal: 8,
     paddingVertical: 8,
     borderRadius: 10,
     backgroundColor: PALETTE.white,
@@ -234,7 +249,15 @@ export const styles = StyleSheet.create({
   },
   summarizeBtnText: { color: APP_COLORS.light.text.primary, fontWeight: '700', fontSize: 13 },
   summarizeBtnTextDark: { color: PALETTE.white },
-  headerTools: { flexDirection: 'row', alignItems: 'center', gap: 8, flexShrink: 1 },
+  // Keep AI buttons visible on small screens; let the Welcome text truncate instead.
+  headerTools: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    flexShrink: 0,
+    flexGrow: 0,
+    flexWrap: 'nowrap',
+  },
   // kept for other modals using the same visual language
   toolBtn: {
     paddingHorizontal: 12,


### PR DESCRIPTION
DM/Group DM chat screen persistence - when opening up the app after it's closed, it should show the last screen you were on, Channel or DM.

Reorganize Top Menu by merging Welcome User into 2nd row, removing chat name, and moving connection status next to Welcome User with an icon.

AsyncStorage for Channel, DM names, username, and avatar so it doesnt flash on opening app.