### PR TITLE
Evan perry/minor UI fixes

### DIFF
--- a/frontend/App.styles.ts
+++ b/frontend/App.styles.ts
@@ -289,9 +289,14 @@ export const styles = StyleSheet.create({
     borderRadius: 10,
   },
   segmentBtnText: {
-    fontSize: 14,
+    fontSize: 16,
+    // Keep the pill height stable: the chip circle is 18px tall, so keep text metrics <= 18.
+    lineHeight: 18,
     fontWeight: '700',
     color: APP_COLORS.light.text.muted,
+    // Helps avoid descender clipping and unexpected extra vertical space (Android).
+    includeFontPadding: false,
+    textAlignVertical: 'center',
   },
   segmentBtnTextDark: {
     color: APP_COLORS.dark.text.secondary,

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -214,8 +214,15 @@ export default function App(): React.JSX.Element {
         <UiPromptProvider isDark={isDark}>
           <Authenticator.Provider>
             {booting ? (
-              <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-                <ActivityIndicator />
+              <View
+                style={{
+                  flex: 1,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  backgroundColor: appColors.appBackground,
+                }}
+              >
+                <ActivityIndicator size="large" color={appColors.appForeground} />
               </View>
             ) : rootMode === 'guest' ? (
               <>

--- a/frontend/src/features/appShell/components/MainAppContent.tsx
+++ b/frontend/src/features/appShell/components/MainAppContent.tsx
@@ -4,7 +4,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { deleteUser, fetchUserAttributes } from 'aws-amplify/auth';
 import React, { useState } from 'react';
 import type { Pressable } from 'react-native';
-import { ActivityIndicator, useWindowDimensions, View } from 'react-native';
+import { useWindowDimensions, View } from 'react-native';
 
 import { styles } from '../../../../App.styles';
 import { AVATAR_DEFAULT_COLORS } from '../../../components/AvatarBubble';
@@ -103,7 +103,13 @@ function looksLikeOpaqueCognitoUsername(s: string): boolean {
 type LastChannelLabelCache = { conversationId: string; label: string };
 const LAST_CHANNEL_LABEL_CACHE_KEY = 'ui:lastChannelLabel:device';
 
-export const MainAppContent = ({ onSignedOut }: { onSignedOut?: () => void }) => {
+export const MainAppContent = ({
+  onSignedOut,
+  onRehydrateReady,
+}: {
+  onSignedOut?: () => void;
+  onRehydrateReady?: (ready: boolean) => void;
+}) => {
   const { user } = useAuthenticator();
   const { signOut } = useAuthenticator();
   const {
@@ -325,6 +331,11 @@ export const MainAppContent = ({ onSignedOut }: { onSignedOut?: () => void }) =>
     unreadDmMap,
   });
   const { lastDmConversationIdRef } = useLastDmConversation({ conversationId });
+
+  const rehydrateReady = channelRestoreDone && conversationRestoreDone;
+  React.useEffect(() => {
+    onRehydrateReady?.(rehydrateReady);
+  }, [onRehydrateReady, rehydrateReady]);
 
   const getIdToken = React.useCallback(async (): Promise<string | null> => {
     return await getIdTokenWithRetry({ maxAttempts: 10, delayMs: 200 });
@@ -825,7 +836,7 @@ export const MainAppContent = ({ onSignedOut }: { onSignedOut?: () => void }) =>
       <MainAppPassphrasePromptModal styles={styles} isDark={isDark} {...passphraseModalProps} />
 
       <View style={{ flex: 1 }}>
-        {channelRestoreDone && conversationRestoreDone ? (
+        {rehydrateReady ? (
           <ChatScreen
             conversationId={conversationId}
             peer={peer}
@@ -854,16 +865,8 @@ export const MainAppContent = ({ onSignedOut }: { onSignedOut?: () => void }) =>
             onBlockUserSub={addBlockBySub}
           />
         ) : (
-          <View
-            style={{
-              flex: 1,
-              alignItems: 'center',
-              justifyContent: 'center',
-              backgroundColor: appColors.appBackground,
-            }}
-          >
-            <ActivityIndicator size="large" color={appColors.appForeground} />
-          </View>
+          // Root-level overlay spinner (App.tsx) stays visible during rehydrate.
+          <View style={{ flex: 1, backgroundColor: appColors.appBackground }} />
         )}
       </View>
     </View>

--- a/frontend/src/features/chat/buildChatScreenMainProps.ts
+++ b/frontend/src/features/chat/buildChatScreenMainProps.ts
@@ -7,6 +7,7 @@ type HeaderProps = MainProps['header'];
 type BodyProps = MainProps['body'];
 type ListProps = MainProps['list'];
 type ComposerProps = MainProps['composer'];
+type SelectionProps = MainProps['selection'];
 
 export function buildChatScreenMainProps(deps: {
   styles: MainProps['styles'];
@@ -103,6 +104,13 @@ export function buildChatScreenMainProps(deps: {
   sendTyping: ComposerProps['sendTyping'];
   sendMessage: ComposerProps['sendMessage'];
   handlePickMedia: ComposerProps['handlePickMedia'];
+
+  selectionActive: SelectionProps['active'];
+  selectionCount: SelectionProps['count'];
+  selectionCanCopy: SelectionProps['canCopy'];
+  selectionOnCancel: SelectionProps['onCancel'];
+  selectionOnCopy: SelectionProps['onCopy'];
+  selectionOnDelete: SelectionProps['onDelete'];
 }): MainProps {
   return {
     styles: deps.styles,
@@ -200,6 +208,14 @@ export function buildChatScreenMainProps(deps: {
       sendTyping: deps.sendTyping,
       sendMessage: deps.sendMessage,
       handlePickMedia: deps.handlePickMedia,
+    },
+    selection: {
+      active: deps.selectionActive,
+      count: deps.selectionCount,
+      canCopy: deps.selectionCanCopy,
+      onCancel: deps.selectionOnCancel,
+      onCopy: deps.selectionOnCopy,
+      onDelete: deps.selectionOnDelete,
     },
   };
 }

--- a/frontend/src/features/chat/components/ChatScreenMain.tsx
+++ b/frontend/src/features/chat/components/ChatScreenMain.tsx
@@ -240,6 +240,26 @@ export function ChatScreenMain({
       // Keeping KAV enabled on Android can create double-adjust gaps depending on IME settings.
       enabled={Platform.OS === 'ios'}
     >
+      {/* Stage 3 loader: center relative to the full screen (same as root spinners),
+          not just the message-list area below the header. */}
+      {showListLoadingOverlay ? (
+        <View
+          pointerEvents="none"
+          style={{
+            position: 'absolute',
+            top: 0,
+            bottom: 0,
+            left: 0,
+            right: 0,
+            alignItems: 'center',
+            justifyContent: 'center',
+            zIndex: 50,
+          }}
+        >
+          <ActivityIndicator size="large" color={appColors.appForeground} />
+        </View>
+      ) : null}
+
       <View style={[styles.header, isDark ? styles.headerDark : null]}>
         <View style={isWideChatLayout ? styles.chatContentColumn : null}>
           {header.headerTop ? <View style={styles.headerTopSlot}>{header.headerTop}</View> : null}
@@ -339,23 +359,6 @@ export function ChatScreenMain({
         {/* Keep the scroll container full-width so the web scrollbar stays at the window edge.
             Center the *content* via FlatList.contentContainerStyle instead. */}
         <View style={styles.chatBodyInner}>
-          {showListLoadingOverlay ? (
-            <View
-              pointerEvents="none"
-              style={{
-                position: 'absolute',
-                top: 0,
-                bottom: 0,
-                left: 0,
-                right: 0,
-                alignItems: 'center',
-                justifyContent: 'center',
-                zIndex: 5,
-              }}
-            >
-              <ActivityIndicator size="large" color={appColors.appForeground} />
-            </View>
-          ) : null}
           <ChatMessageList
             styles={styles}
             isDark={isDark}

--- a/frontend/src/features/chat/components/ChatScreenOverlays.tsx
+++ b/frontend/src/features/chat/components/ChatScreenOverlays.tsx
@@ -528,6 +528,7 @@ export function ChatScreenOverlays(props: ChatScreenOverlaysProps): React.JSX.El
         uiConfirm={uiConfirm}
         showAlert={camera.showAlert}
         close={messageActionMenu.closeMenu}
+        copyToClipboard={copyToClipboard}
         sendReaction={messageOps.sendReaction}
         openReactionPicker={messageOps.openReactionPicker}
         setCipherText={messageOps.setCipherText}

--- a/frontend/src/features/chat/components/ChatScreenOverlays.tsx
+++ b/frontend/src/features/chat/components/ChatScreenOverlays.tsx
@@ -33,6 +33,7 @@ import { SummaryModal } from './SummaryModal';
 import { TtlPickerModal } from './TtlPickerModal';
 
 type UiConfirm = React.ComponentProps<typeof MessageActionMenuModal>['uiConfirm'];
+type UiChoice3 = React.ComponentProps<typeof MessageActionMenuModal>['uiChoice3'];
 type ReportCdnMedia = React.ComponentProps<typeof ReportModal>['cdnMedia'];
 
 type AiHelperController = {
@@ -180,7 +181,11 @@ export type ChatScreenOverlaysProps = {
   blockedSubsSet: Set<string>;
   onBlockUserSub?: (blockedSub: string, label?: string) => void | Promise<void>;
   uiConfirm: UiConfirm;
+  uiChoice3: UiChoice3;
   messageOps: MessageOps;
+  // Multi-select
+  selectionActive?: boolean;
+  onSelectMessage?: (msg: ChatMessage) => void;
 
   reactionPickerOpen: boolean;
   reactionPickerTarget: ChatMessage | null;
@@ -320,7 +325,10 @@ export function ChatScreenOverlays(props: ChatScreenOverlaysProps): React.JSX.El
     blockedSubsSet,
     onBlockUserSub,
     uiConfirm,
+    uiChoice3,
     messageOps,
+    selectionActive,
+    onSelectMessage,
     reactionPickerOpen,
     reactionPickerTarget,
     emojis,
@@ -526,9 +534,12 @@ export function ChatScreenOverlays(props: ChatScreenOverlaysProps): React.JSX.El
         blockedSubsSet={blockedSubsSet}
         onBlockUserSub={onBlockUserSub}
         uiConfirm={uiConfirm}
+        uiChoice3={uiChoice3}
         showAlert={camera.showAlert}
         close={messageActionMenu.closeMenu}
         copyToClipboard={copyToClipboard}
+        selectionActive={!!selectionActive}
+        onSelectMessage={onSelectMessage}
         sendReaction={messageOps.sendReaction}
         openReactionPicker={messageOps.openReactionPicker}
         setCipherText={messageOps.setCipherText}

--- a/frontend/src/features/chat/getCopyableMessageText.ts
+++ b/frontend/src/features/chat/getCopyableMessageText.ts
@@ -1,0 +1,57 @@
+import {
+  normalizeChatMediaList,
+  normalizeDmMediaItems,
+  normalizeGroupMediaItems,
+  parseChatEnvelope,
+  parseDmMediaEnvelope,
+  parseGroupMediaEnvelope,
+} from './parsers';
+import type { ChatMessage } from './types';
+
+/**
+ * Returns the text that should be copied for a message, or null if there's nothing to copy.
+ *
+ * Rules:
+ * - Text message: copy its text.
+ * - Media message: copy its caption ONLY (if present). If no caption, return null.
+ * - Deleted: null
+ * - Encrypted but not decrypted yet: null
+ */
+export function getCopyableMessageText(args: { msg: ChatMessage; isDm: boolean }): string | null {
+  const { msg: t, isDm } = args;
+
+  if (!t) return null;
+  if (t.deletedAt) return null;
+  if ((t.encrypted || t.groupEncrypted) && !t.decryptedText) return null;
+
+  let text = '';
+
+  // Encrypted chats: decryptedText can be either a media envelope (caption field)
+  // or plain text.
+  if (t.encrypted || t.groupEncrypted) {
+    const plain = String(t.decryptedText || '');
+    const dmEnv = parseDmMediaEnvelope(plain);
+    const dmItems = dmEnv ? normalizeDmMediaItems(dmEnv) : [];
+    const gEnv = parseGroupMediaEnvelope(plain);
+    const gItems = gEnv ? normalizeGroupMediaItems(gEnv) : [];
+    if (dmItems.length || gItems.length) {
+      text = String((dmEnv?.caption ?? gEnv?.caption) || '');
+    } else {
+      text = plain;
+    }
+  } else {
+    // Plain chats: channel/global can have a JSON envelope for media attachments.
+    const raw = String(t.rawText ?? t.text ?? '');
+    const env = !isDm ? parseChatEnvelope(raw) : null;
+    const envList = env ? normalizeChatMediaList(env.media) : [];
+    if (envList.length) {
+      // Caption lives ONLY in env.text.
+      text = String(env?.text || '');
+    } else {
+      text = raw;
+    }
+  }
+
+  const trimmed = String(text || '').trim();
+  return trimmed ? trimmed : null;
+}

--- a/frontend/src/features/chat/renderChatListItem.tsx
+++ b/frontend/src/features/chat/renderChatListItem.tsx
@@ -103,6 +103,11 @@ export function renderChatListItem(args: {
   openMessageActions: (m: ChatMessage, anchor: Anchor) => void;
   latestOutgoingMessageId: string | null;
   retryFailedMessage: (m: ChatMessage) => void;
+
+  // Multi-select mode
+  selectionActive: boolean;
+  selectedIdSet: Set<string>;
+  toggleSelectedMessageId: (id: string) => void;
 }): React.JSX.Element {
   const {
     styles,
@@ -153,6 +158,9 @@ export function renderChatListItem(args: {
     openMessageActions,
     latestOutgoingMessageId,
     retryFailedMessage,
+    selectionActive,
+    selectedIdSet,
+    toggleSelectedMessageId,
   } = args;
 
   if (item.kind === 'system') {
@@ -532,6 +540,9 @@ export function renderChatListItem(args: {
         const y = Number(yRaw) || 0;
         openMessageActions(item, { x, y });
       }}
+      selectionActive={selectionActive}
+      isSelected={selectedIdSet.has(String(item.id))}
+      onToggleSelected={() => toggleSelectedMessageId(String(item.id))}
       latestOutgoingMessageId={latestOutgoingMessageId}
       retryFailedMessage={retryFailedMessage}
       renderMediaCarousel={renderMediaCarousel}

--- a/frontend/src/features/chat/useChatInlineEditActions.ts
+++ b/frontend/src/features/chat/useChatInlineEditActions.ts
@@ -1,3 +1,4 @@
+import { bytesToHex } from '@noble/hashes/utils.js';
 import type { RefObject } from 'react';
 import * as React from 'react';
 
@@ -9,7 +10,9 @@ import type {
   ChatMessage,
   DmMediaEnvelope,
   DmMediaEnvelopeV1,
+  EncryptedGroupPayloadV1,
   GroupMediaEnvelope,
+  GroupMediaEnvelopeV1,
 } from './types';
 
 function getErrorMessage(err: unknown): string {
@@ -32,6 +35,7 @@ export function useChatInlineEditActions(opts: {
   wsRef: RefObject<WebSocket | null>;
   activeConversationId: string;
   isDm: boolean;
+  isGroup: boolean;
 
   messages: ChatMessage[];
   setMessages: React.Dispatch<React.SetStateAction<ChatMessage[]>>;
@@ -52,6 +56,10 @@ export function useChatInlineEditActions(opts: {
   clearPendingMedia: () => void;
 
   // crypto
+  myUserId: string | null | undefined;
+  groupMembers: Array<{ status: string; memberSub: string }>;
+  groupPublicKeyBySub: Record<string, string | undefined>;
+  getRandomBytes: (n: number) => Uint8Array;
   myPrivateKey: string | null | undefined;
   peerPublicKey: string | null | undefined;
   encryptChatMessageV1: (
@@ -60,6 +68,27 @@ export function useChatInlineEditActions(opts: {
     peerPublicKey: string,
   ) => EncryptedChatPayloadV1;
   parseEncrypted: (s: string) => EncryptedChatPayloadV1 | null;
+  parseGroupEncrypted: (s: string) => EncryptedGroupPayloadV1 | null;
+  prepareGroupMediaPlaintext: (args: {
+    conversationId: string;
+    pendingMedia: PendingMediaItem[] | null | undefined;
+    caption: string;
+    messageKeyBytes: Uint8Array;
+    uploadPendingMediaGroupEncrypted: (
+      item: PendingMediaItem,
+      conversationId: string,
+      messageKeyBytes: Uint8Array,
+      caption?: string,
+    ) => Promise<GroupMediaEnvelopeV1>;
+  }) => Promise<{ plaintextToEncrypt: string; mediaPathsToSend: string[] }>;
+  encryptGroupOutgoingEncryptedText: (args: {
+    plaintextToEncrypt: string;
+    messageKeyBytes: Uint8Array;
+    myPrivateKey: string;
+    myUserId: string;
+    activeMemberSubs: string[];
+    groupPublicKeyBySub: Record<string, string | undefined>;
+  }) => string;
 
   // parsing/normalizing (passed in to avoid deep imports)
   parseChatEnvelope: (raw: string) => ChatEnvelope | null;
@@ -77,6 +106,12 @@ export function useChatInlineEditActions(opts: {
     recipientPublicKeyHex: string,
     captionOverride?: string,
   ) => Promise<DmMediaEnvelopeV1>;
+  uploadPendingMediaGroupEncrypted: (
+    media: PendingMediaItem,
+    conversationKey: string,
+    messageKeyBytes: Uint8Array,
+    captionOverride?: string,
+  ) => Promise<GroupMediaEnvelopeV1>;
 
   // ui
   openInfo: (title: string, body: string) => void;
@@ -87,6 +122,7 @@ export function useChatInlineEditActions(opts: {
     wsRef,
     activeConversationId,
     isDm,
+    isGroup,
     messages,
     setMessages,
     setError,
@@ -100,17 +136,25 @@ export function useChatInlineEditActions(opts: {
     setInlineEditUploading,
     pendingMediaRef,
     clearPendingMedia,
+    myUserId,
+    groupMembers,
+    groupPublicKeyBySub,
+    getRandomBytes,
     myPrivateKey,
     peerPublicKey,
     encryptChatMessageV1,
     parseEncrypted,
+    parseGroupEncrypted,
+    prepareGroupMediaPlaintext,
+    encryptGroupOutgoingEncryptedText,
     parseChatEnvelope,
     parseDmMediaEnvelope,
     parseGroupMediaEnvelope,
     normalizeDmMediaItems,
-    normalizeGroupMediaItems: _normalizeGroupMediaItems,
+    normalizeGroupMediaItems,
     uploadPendingMedia,
     uploadPendingMediaDmEncrypted,
+    uploadPendingMediaGroupEncrypted,
     openInfo,
     showAlert,
     closeMessageActions,
@@ -203,9 +247,16 @@ export function useChatInlineEditActions(opts: {
     let dmMediaSent: ChatMessage['media'] | undefined = undefined;
     let dmMediaListSent: MediaItem[] | undefined = undefined;
     let dmMediaPathsSent: string[] | undefined = undefined;
-    const needsEncryption = isDm && !!target.encrypted;
+    let groupPlaintextSent: string | null = null;
+    let groupMediaSent: ChatMessage['media'] | undefined = undefined;
+    let groupMediaListSent: MediaItem[] | undefined = undefined;
+    let groupMediaPathsSent: string[] | undefined = undefined;
+    let groupKeyHexSent: string | undefined = undefined;
 
-    if (needsEncryption) {
+    const needsDmEncryption = isDm && !!target.encrypted;
+    const needsGroupEncryption = isGroup && !!target.groupEncrypted;
+
+    if (needsDmEncryption) {
       if (!myPrivateKey || !peerPublicKey) {
         showAlert('Encryption not ready', 'Missing keys for editing.');
         return;
@@ -278,6 +329,86 @@ export function useChatInlineEditActions(opts: {
 
       const enc = encryptChatMessageV1(plaintextToEncrypt, myPrivateKey, peerPublicKey);
       outgoingText = JSON.stringify(enc);
+    } else if (needsGroupEncryption) {
+      if (!myPrivateKey || !myUserId) {
+        showAlert('Encryption not ready', 'Missing keys for editing.');
+        return;
+      }
+      const activeMemberSubs = groupMembers
+        .filter((m) => m && m.status === 'active' && m.memberSub)
+        .map((m) => String(m.memberSub))
+        .filter(Boolean);
+      if (!activeMemberSubs.length) {
+        showAlert('Encryption not ready', 'Missing active group members for editing.');
+        return;
+      }
+
+      // For group edits we mint a new per-message key (same as sending a new message).
+      const messageKeyBytes = getRandomBytes(32);
+      groupKeyHexSent = bytesToHex(messageKeyBytes);
+
+      // If this is a Group DM media message:
+      // - keep: update caption only (preserve existing gdm_media envelope)
+      // - replace: upload new group-encrypted media + create new gdm_media_v1/v2 envelope
+      // - remove: send plain text (caption only) group message
+      let plaintextToEncrypt = nextCaption;
+      const existingPlain = String(target.decryptedText || '');
+      const existingGEnv = parseGroupMediaEnvelope(existingPlain);
+
+      if (
+        inlineEditAttachmentMode === 'replace' &&
+        pendingMediaRef.current &&
+        pendingMediaRef.current.length
+      ) {
+        setInlineEditUploading(true);
+        try {
+          const prepared = await prepareGroupMediaPlaintext({
+            conversationId: activeConversationId,
+            pendingMedia: pendingMediaRef.current,
+            caption: nextCaption,
+            messageKeyBytes,
+            uploadPendingMediaGroupEncrypted,
+          });
+          plaintextToEncrypt = prepared.plaintextToEncrypt;
+          groupMediaPathsSent = prepared.mediaPathsToSend;
+        } finally {
+          setInlineEditUploading(false);
+        }
+      } else if (inlineEditAttachmentMode === 'keep' && existingGEnv) {
+        plaintextToEncrypt = JSON.stringify({
+          ...existingGEnv,
+          caption: nextCaption || undefined,
+        });
+      }
+
+      groupPlaintextSent = plaintextToEncrypt;
+      const parsed = parseGroupMediaEnvelope(groupPlaintextSent);
+      const gItems = normalizeGroupMediaItems(parsed);
+      if (gItems.length) {
+        groupMediaListSent = gItems.map((it) => ({
+          path: it.media.path,
+          thumbPath: it.media.thumbPath,
+          kind: it.media.kind,
+          contentType: it.media.contentType,
+          thumbContentType: it.media.thumbContentType,
+          fileName: it.media.fileName,
+          size: it.media.size,
+          durationMs: it.media.durationMs,
+        }));
+        groupMediaSent = groupMediaListSent[0];
+        groupMediaPathsSent = gItems
+          .flatMap((it) => [it.media.path, it.media.thumbPath].filter(Boolean))
+          .map(String);
+      }
+
+      outgoingText = encryptGroupOutgoingEncryptedText({
+        plaintextToEncrypt,
+        messageKeyBytes,
+        myPrivateKey,
+        myUserId,
+        activeMemberSubs,
+        groupPublicKeyBySub,
+      });
     } else if (!isDm) {
       // Global messages:
       // - keep: if it's a media envelope, preserve media and update caption
@@ -316,17 +447,24 @@ export function useChatInlineEditActions(opts: {
     }
 
     try {
+      const mediaPathsPayload =
+        needsDmEncryption && inlineEditAttachmentMode === 'remove'
+          ? { mediaPaths: [] }
+          : needsDmEncryption && inlineEditAttachmentMode === 'replace'
+            ? { mediaPaths: dmMediaPathsSent || [] }
+            : needsGroupEncryption && inlineEditAttachmentMode === 'remove'
+              ? { mediaPaths: [] }
+              : needsGroupEncryption && inlineEditAttachmentMode === 'replace'
+                ? { mediaPaths: groupMediaPathsSent || [] }
+                : {};
+
       wsRef.current.send(
         JSON.stringify({
           action: 'edit',
           conversationId: activeConversationId,
           messageCreatedAt: target.createdAt,
           text: outgoingText,
-          ...(needsEncryption && inlineEditAttachmentMode === 'remove'
-            ? { mediaPaths: [] }
-            : needsEncryption && inlineEditAttachmentMode === 'replace'
-              ? { mediaPaths: dmMediaPathsSent || [] }
-              : {}),
+          ...mediaPathsPayload,
           createdAt: Date.now(),
         }),
       );
@@ -337,7 +475,8 @@ export function useChatInlineEditActions(opts: {
       let optimisticDecryptedText: string | undefined = undefined;
       let optimisticMedia: ChatMessage['media'] | undefined = undefined;
       let optimisticMediaList: ChatMessage['mediaList'] | undefined = undefined;
-      if (needsEncryption) {
+      let optimisticGroupKeyHex: string | undefined = undefined;
+      if (needsDmEncryption) {
         if (inlineEditAttachmentMode === 'remove') {
           optimisticDecryptedText = nextCaption;
           optimisticMedia = undefined;
@@ -349,6 +488,19 @@ export function useChatInlineEditActions(opts: {
         } else {
           optimisticDecryptedText = nextCaption;
         }
+      } else if (needsGroupEncryption) {
+        optimisticGroupKeyHex = groupKeyHexSent;
+        if (inlineEditAttachmentMode === 'remove') {
+          optimisticDecryptedText = nextCaption;
+          optimisticMedia = undefined;
+          optimisticMediaList = undefined;
+        } else if (groupPlaintextSent) {
+          optimisticDecryptedText = groupPlaintextSent;
+          optimisticMedia = groupMediaSent;
+          optimisticMediaList = groupMediaListSent;
+        } else {
+          optimisticDecryptedText = nextCaption;
+        }
       }
       setMessages((prev) =>
         prev.map((m) =>
@@ -356,10 +508,16 @@ export function useChatInlineEditActions(opts: {
             ? {
                 ...m,
                 rawText: outgoingText,
-                encrypted: parseEncrypted(outgoingText) ?? undefined,
-                decryptedText: needsEncryption ? optimisticDecryptedText : m.decryptedText,
-                media: needsEncryption ? optimisticMedia : m.media,
-                mediaList: needsEncryption ? optimisticMediaList : m.mediaList,
+                encrypted: needsDmEncryption ? parseEncrypted(outgoingText) ?? undefined : m.encrypted,
+                groupEncrypted: needsGroupEncryption
+                  ? parseGroupEncrypted(outgoingText) ?? undefined
+                  : m.groupEncrypted,
+                decryptedText:
+                  needsDmEncryption || needsGroupEncryption ? optimisticDecryptedText : m.decryptedText,
+                groupKeyHex: needsGroupEncryption ? optimisticGroupKeyHex : m.groupKeyHex,
+                decryptFailed: needsDmEncryption || needsGroupEncryption ? undefined : m.decryptFailed,
+                media: needsDmEncryption || needsGroupEncryption ? optimisticMedia : m.media,
+                mediaList: needsDmEncryption || needsGroupEncryption ? optimisticMediaList : m.mediaList,
                 // Always show the edited caption in the UI (even for envelopes).
                 text: nextCaption,
                 editedAt: now,
@@ -375,16 +533,26 @@ export function useChatInlineEditActions(opts: {
     activeConversationId,
     cancelInlineEdit,
     encryptChatMessageV1,
+    encryptGroupOutgoingEncryptedText,
+    getRandomBytes,
+    groupMembers,
+    groupPublicKeyBySub,
     inlineEditAttachmentMode,
     inlineEditDraft,
     inlineEditTargetId,
     inlineEditUploading,
+    isGroup,
     messages,
+    myUserId,
     myPrivateKey,
     normalizeDmMediaItems,
+    normalizeGroupMediaItems,
     parseChatEnvelope,
     parseDmMediaEnvelope,
     parseEncrypted,
+    parseGroupEncrypted,
+    parseGroupMediaEnvelope,
+    prepareGroupMediaPlaintext,
     peerPublicKey,
     pendingMediaRef,
     setError,
@@ -393,6 +561,7 @@ export function useChatInlineEditActions(opts: {
     showAlert,
     uploadPendingMedia,
     uploadPendingMediaDmEncrypted,
+    uploadPendingMediaGroupEncrypted,
     wsRef,
     isDm,
     openInfo,

--- a/frontend/src/features/guest/components/GuestGlobalHeaderRow.tsx
+++ b/frontend/src/features/guest/components/GuestGlobalHeaderRow.tsx
@@ -39,15 +39,15 @@ export function GuestGlobalHeaderRow({
             pressed ? { opacity: 0.9 } : null,
           ]}
           accessibilityRole="button"
-          accessibilityLabel="Browse channels"
+          accessibilityLabel="Find channels"
         >
           <Text style={[styles.headerTitle, isDark && styles.headerTitleDark]} numberOfLines={1}>
             {activeChannelTitle}
           </Text>
           <Feather
-            name="chevron-down"
-            size={16}
-            color={isDark ? APP_COLORS.dark.text.primary : APP_COLORS.light.text.primary}
+            name="search"
+            size={18}
+            color={isDark ? APP_COLORS.dark.text.muted : APP_COLORS.light.text.muted}
           />
         </Pressable>
         <View style={styles.headerRight}>

--- a/frontend/src/features/guest/components/GuestGlobalMessageList.tsx
+++ b/frontend/src/features/guest/components/GuestGlobalMessageList.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { FlatList, Platform, RefreshControl, Text, View } from 'react-native';
 
-import { AnimatedDots } from '../../../components/AnimatedDots';
 import type { PublicAvatarProfileLite } from '../../../hooks/usePublicAvatarProfiles';
 import type { WebPinnedListState } from '../../../hooks/useWebPinnedList';
 import type { useWebWheelRefresh } from '../../../hooks/useWebWheelRefresh';
@@ -22,7 +21,7 @@ export function GuestGlobalMessageList({
   messageListData,
   // Error/loading
   error,
-  loading,
+  loading: _loading,
   refreshing,
   fetchNow,
   // History paging
@@ -91,26 +90,6 @@ export function GuestGlobalMessageList({
         >
           {error}
         </Text>
-      ) : null}
-
-      {loading && messages.length === 0 ? (
-        <View style={[styles.loadingWrap, isWideUi ? styles.contentColumn : null]}>
-          <View style={{ flexDirection: 'row', alignItems: 'center' }}>
-            <Text
-              style={{
-                color: isDark ? APP_COLORS.dark.text.body : APP_COLORS.light.text.secondary,
-                fontWeight: '700',
-                fontSize: 14,
-              }}
-            >
-              Loading
-            </Text>
-            <AnimatedDots
-              color={isDark ? APP_COLORS.dark.text.body : APP_COLORS.light.text.secondary}
-              size={16}
-            />
-          </View>
-        </View>
       ) : null}
 
       {/* Keep the scroll container full-width so the web scrollbar stays at the window edge.

--- a/frontend/src/screens/GuestGlobalScreen.styles.ts
+++ b/frontend/src/screens/GuestGlobalScreen.styles.ts
@@ -33,7 +33,8 @@ export const styles = StyleSheet.create({
   },
   contentColumn: { width: '100%', maxWidth: 1040, alignSelf: 'center' },
   headerTitle: {
-    fontSize: 18,
+    fontSize: 20,
+    lineHeight: 24,
     fontWeight: '800',
     color: APP_COLORS.light.text.primary,
   },


### PR DESCRIPTION
Change Channel Search Caret to Search Icon Guest

Increase font size of Channel/DM name (guest and signed in) while leaving row and containers same height

Singular appearing Loading spinner. Instead of 2 different loading spinners for Boot/Message hydration, they appear the same even though the logic is still 2 separate spinners. Both guest and signed in users.

Persistent Light/Dark Mode

Loading UI streamlined on sign in. There are 3 stages - App Boot and checking auth session, stage 2 is signed in rehydrating for last channel/convo/avatar, and then stage 3 is chat hydration. First 2 stages use the same overlay spinner to appear as one loading, 3rd stage is so we can see the app loaded and is just loading messages.

Also remove the 3rd stage repeating for correct styling of content in chatscreen (messages appear not formatted correctly, loading spinner again, then messages appear formatted correctly). We wait for the first screen worth of media tiles to have their aspect ratios before finishing this loading spinner.

All 3 stage spinner centered.

Copy Message option added. Only copies text or captions, not media.

Dark Mode Appropriate message preview in Message Options

Select Message option for selecting multiple Messages (Copy, Delete for Me - with confirmation, Cancel options)

Delete for Me and Delete for Everyone merged to Delete... to reduce Message Options size, now a modal appears offering which option they would like (also serves as the confirmation modal).

Fix bug where Add/Remove/Replace attachments wasn't working in Group DMs properly

Increase gap above file tile and save/cancel when editing

Margin below Welcome row on Global channel when signed in.

Remove Settings -> About in DM/Group DMs


