### PR TITLE
Home screen per user and Guest

### DIFF
--- a/frontend/App.styles.ts
+++ b/frontend/App.styles.ts
@@ -32,7 +32,9 @@ export const styles = StyleSheet.create({
     // Keep it feeling like a popup, not a full screen.
     // ScrollView inside will handle overflow on small screens.
     maxHeight: 640,
-    minHeight: 360,
+    // Allow short auth screens (e.g. "Reset Password" email step) to shrink
+    // instead of leaving a large blank area under the content.
+    minHeight: 280,
     borderRadius: 16,
     backgroundColor: APP_COLORS.light.bg.app,
     overflow: 'hidden',

--- a/frontend/src/components/AppTextInput.tsx
+++ b/frontend/src/components/AppTextInput.tsx
@@ -92,6 +92,9 @@ export const AppTextInput = React.forwardRef<TextInput, AppTextInputProps>(funct
     style,
     onFocus,
     onBlur,
+    onKeyPress,
+    onSubmitEditing,
+    multiline,
     ...props
   },
   ref,
@@ -134,6 +137,29 @@ export const AppTextInput = React.forwardRef<TextInput, AppTextInputProps>(funct
         focused ? focusStyle : null,
         style,
       ]}
+      multiline={multiline}
+      onSubmitEditing={onSubmitEditing}
+      // RN-web: Enter can blur instead of submitting. Intercept and route to submit.
+      {...(Platform.OS === 'web' && typeof onSubmitEditing === 'function' && !multiline
+        ? ({
+            onKeyPress: (e: unknown) => {
+              onKeyPress?.(e as any);
+              const ev = e as {
+                nativeEvent?: { key?: string; shiftKey?: boolean };
+                preventDefault?: () => void;
+                stopPropagation?: () => void;
+              };
+              const key = String(ev?.nativeEvent?.key ?? '');
+              const shift = !!ev?.nativeEvent?.shiftKey;
+              if (key === 'Enter' && !shift) {
+                ev.preventDefault?.();
+                ev.stopPropagation?.();
+                // Most callers don't use the event object; keep it simple.
+                (onSubmitEditing as unknown as (() => void))?.();
+              }
+            },
+          } as const)
+        : ({ onKeyPress } as const))}
       {...props}
     />
   );

--- a/frontend/src/components/AppTextInput.tsx
+++ b/frontend/src/components/AppTextInput.tsx
@@ -155,7 +155,7 @@ export const AppTextInput = React.forwardRef<TextInput, AppTextInputProps>(funct
                 ev.preventDefault?.();
                 ev.stopPropagation?.();
                 // Most callers don't use the event object; keep it simple.
-                (onSubmitEditing as unknown as (() => void))?.();
+                (onSubmitEditing as unknown as () => void)?.();
               }
             },
           } as const)

--- a/frontend/src/components/media/FileAttachmentTile.tsx
+++ b/frontend/src/components/media/FileAttachmentTile.tsx
@@ -1,5 +1,6 @@
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import React from 'react';
+import type { GestureResponderEvent } from 'react-native';
 import { Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { useUiPromptOptional } from '../../providers/UiPromptProvider';
@@ -35,12 +36,14 @@ export function FileAttachmentTile({
   isDark,
   isOutgoing,
   onPress,
+  onLongPress,
   onDownload,
 }: {
   item: MediaItem;
   isDark: boolean;
   isOutgoing: boolean;
   onPress: () => void | Promise<void>;
+  onLongPress?: (e: GestureResponderEvent) => void;
   onDownload?: () => void | Promise<void>;
 }): React.JSX.Element {
   const badge = fileBadgeForMedia(item);
@@ -97,6 +100,7 @@ export function FileAttachmentTile({
   return (
     <Pressable
       onPress={() => void onPress()}
+      onLongPress={onLongPress}
       accessibilityRole="button"
       accessibilityLabel={`Open ${name}`}
       style={({ pressed }) => [

--- a/frontend/src/components/media/MediaStackCarousel.tsx
+++ b/frontend/src/components/media/MediaStackCarousel.tsx
@@ -489,7 +489,10 @@ export function MediaStackCarousel({
                   ? ({
                       onContextMenu: (e: unknown) => {
                         if (!onLongPress) return;
-                        const ev = e as { preventDefault?: () => void; stopPropagation?: () => void };
+                        const ev = e as {
+                          preventDefault?: () => void;
+                          stopPropagation?: () => void;
+                        };
                         ev.preventDefault?.();
                         ev.stopPropagation?.();
                       },

--- a/frontend/src/components/modals/AuthModal.tsx
+++ b/frontend/src/components/modals/AuthModal.tsx
@@ -201,26 +201,26 @@ export function AuthModal({
                 : null,
             ]}
           >
-            <View style={[styles.authModalTopRow, isDark && styles.authModalTopRowDark]}>
-              <View style={{ width: 44 }} />
-              <Text style={[styles.authModalTitle, isDark && styles.authModalTitleDark]}>
-                Sign in
-              </Text>
-              <Pressable
-                onPress={onClose}
-                style={({ pressed }) => [
-                  styles.authModalCloseCircle,
-                  isDark && styles.authModalCloseCircleDark,
-                  pressed && { opacity: 0.85 },
-                ]}
-                accessibilityRole="button"
-                accessibilityLabel="Close sign in"
-              >
-                <Text style={[styles.authModalCloseX, isDark && styles.authModalCloseXDark]}>
-                  ×
-                </Text>
-              </Pressable>
-            </View>
+            {/* Close button aligned with Authenticator header row (removes dead top space). */}
+            <Pressable
+              onPress={onClose}
+              style={({ pressed }) => [
+                styles.authModalCloseCircle,
+                isDark && styles.authModalCloseCircleDark,
+                {
+                  position: 'absolute',
+                  top: 10,
+                  right: 10,
+                  zIndex: 10,
+                  marginTop: 0,
+                },
+                pressed && { opacity: 0.85 },
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel="Close"
+            >
+              <Text style={[styles.authModalCloseX, isDark && styles.authModalCloseXDark]}>×</Text>
+            </Pressable>
 
             <ThemeProvider theme={amplifyTheme} colorMode={isDark ? 'dark' : 'light'}>
               <ScrollView

--- a/frontend/src/features/appShell/components/MainAppBlocklistModal.tsx
+++ b/frontend/src/features/appShell/components/MainAppBlocklistModal.tsx
@@ -105,6 +105,8 @@ export function MainAppBlocklistModal({
               autoCorrect={false}
               baseStyle={styles.blocksInput}
               darkStyle={styles.blocksInputDark}
+              returnKeyType="done"
+              onSubmitEditing={() => void Promise.resolve(addBlockByUsername())}
             />
             <Pressable
               onPress={() => void Promise.resolve(addBlockByUsername())}

--- a/frontend/src/features/appShell/components/MainAppContent.tsx
+++ b/frontend/src/features/appShell/components/MainAppContent.tsx
@@ -319,6 +319,7 @@ export const MainAppContent = ({
   const isDmMode = conversationId.startsWith('dm#') || conversationId.startsWith('gdm#');
   const isChannelMode = !isDmMode;
   const { channelRestoreDone, lastChannelConversationIdRef } = useLastChannelConversation({
+    userSub: myUserSub,
     conversationId,
     setConversationId,
   });
@@ -330,7 +331,10 @@ export const MainAppContent = ({
     serverConversations,
     unreadDmMap,
   });
-  const { lastDmConversationIdRef } = useLastDmConversation({ conversationId });
+  const { dmRestoreDone, lastDmConversationIdRef } = useLastDmConversation({
+    userSub: myUserSub,
+    conversationId,
+  });
 
   const rehydrateReady = channelRestoreDone && conversationRestoreDone;
   React.useEffect(() => {
@@ -494,7 +498,7 @@ export const MainAppContent = ({
   const activeChannelConversationId = React.useMemo(() => {
     if (!isDmMode) return conversationId || 'global';
     return lastChannelConversationIdRef.current || 'global';
-  }, [isDmMode, conversationId, lastChannelConversationIdRef]);
+  }, [channelRestoreDone, isDmMode, conversationId, lastChannelConversationIdRef]);
 
   const activeChannelLabel = React.useMemo(() => {
     if (activeChannelConversationId === 'global') return 'Global';
@@ -546,7 +550,7 @@ export const MainAppContent = ({
     const fromChats = chatsList.find((c) => c.conversationId === cid);
     const t = String(fromChats?.peer || unreadDmMap[cid]?.user || '').trim();
     return t || 'DM';
-  }, [chatsList, isDmMode, lastDmConversationIdRef, peer, unreadDmMap]);
+  }, [chatsList, dmRestoreDone, isDmMode, lastDmConversationIdRef, peer, unreadDmMap]);
 
   const { goToConversation } = useConversationNavigation({
     serverConversations,

--- a/frontend/src/features/appShell/components/MainAppContent.tsx
+++ b/frontend/src/features/appShell/components/MainAppContent.tsx
@@ -498,7 +498,7 @@ export const MainAppContent = ({
   const activeChannelConversationId = React.useMemo(() => {
     if (!isDmMode) return conversationId || 'global';
     return lastChannelConversationIdRef.current || 'global';
-  }, [channelRestoreDone, isDmMode, conversationId, lastChannelConversationIdRef]);
+  }, [isDmMode, conversationId]);
 
   const activeChannelLabel = React.useMemo(() => {
     if (activeChannelConversationId === 'global') return 'Global';
@@ -550,7 +550,7 @@ export const MainAppContent = ({
     const fromChats = chatsList.find((c) => c.conversationId === cid);
     const t = String(fromChats?.peer || unreadDmMap[cid]?.user || '').trim();
     return t || 'DM';
-  }, [chatsList, dmRestoreDone, isDmMode, lastDmConversationIdRef, peer, unreadDmMap]);
+  }, [chatsList, isDmMode, peer, unreadDmMap]);
 
   const { goToConversation } = useConversationNavigation({
     serverConversations,

--- a/frontend/src/features/appShell/components/MainAppContent.tsx
+++ b/frontend/src/features/appShell/components/MainAppContent.tsx
@@ -331,7 +331,7 @@ export const MainAppContent = ({
     serverConversations,
     unreadDmMap,
   });
-  const { dmRestoreDone, lastDmConversationIdRef } = useLastDmConversation({
+  const { lastDmConversationIdRef } = useLastDmConversation({
     userSub: myUserSub,
     conversationId,
   });
@@ -498,7 +498,7 @@ export const MainAppContent = ({
   const activeChannelConversationId = React.useMemo(() => {
     if (!isDmMode) return conversationId || 'global';
     return lastChannelConversationIdRef.current || 'global';
-  }, [isDmMode, conversationId]);
+  }, [conversationId, isDmMode, lastChannelConversationIdRef]);
 
   const activeChannelLabel = React.useMemo(() => {
     if (activeChannelConversationId === 'global') return 'Global';
@@ -550,7 +550,7 @@ export const MainAppContent = ({
     const fromChats = chatsList.find((c) => c.conversationId === cid);
     const t = String(fromChats?.peer || unreadDmMap[cid]?.user || '').trim();
     return t || 'DM';
-  }, [chatsList, isDmMode, peer, unreadDmMap]);
+  }, [chatsList, isDmMode, lastDmConversationIdRef, peer, unreadDmMap]);
 
   const { goToConversation } = useConversationNavigation({
     serverConversations,

--- a/frontend/src/features/appShell/components/MainAppHeaderTop.tsx
+++ b/frontend/src/features/appShell/components/MainAppHeaderTop.tsx
@@ -240,6 +240,8 @@ export function MainAppHeaderTop({
               placeholder="Enter Names"
               baseStyle={styles.searchInput}
               darkStyle={styles.searchInputDark}
+              returnKeyType="go"
+              onSubmitEditing={() => void Promise.resolve(onStartDm())}
             />
             <Pressable
               onPress={() => void Promise.resolve(onStartDm())}

--- a/frontend/src/features/appShell/components/MainAppPassphrasePromptModal.tsx
+++ b/frontend/src/features/appShell/components/MainAppPassphrasePromptModal.tsx
@@ -1,5 +1,6 @@
 import { icons } from '@aws-amplify/ui-react-native/dist/assets';
 import React from 'react';
+import type { TextInput } from 'react-native';
 import { Image, Modal, Platform, Pressable, Text, View } from 'react-native';
 
 import type { AppStyles } from '../../../../App.styles';
@@ -71,6 +72,22 @@ export function MainAppPassphrasePromptModal({
   const submitDisabled =
     processing || !passphraseInput.trim() || (requiresConfirm && !passphraseConfirmInput.trim());
 
+  const confirmRef = React.useRef<TextInput | null>(null);
+  const handlePassphraseSubmit = React.useCallback(() => {
+    if (processing) return;
+    if (requiresConfirm) {
+      confirmRef.current?.focus?.();
+      return;
+    }
+    if (!passphraseInput.trim()) return;
+    onSubmit();
+  }, [onSubmit, passphraseInput, processing, requiresConfirm]);
+
+  const handleConfirmSubmit = React.useCallback(() => {
+    if (submitDisabled) return;
+    onSubmit();
+  }, [onSubmit, submitDisabled]);
+
   const helperText =
     mode === 'setup'
       ? 'Make sure you remember your passphrase for future device recovery - we do not store it.'
@@ -121,6 +138,9 @@ export function MainAppPassphrasePromptModal({
           placeholder="Enter Passphrase"
           autoFocus
           editable={!processing}
+          returnKeyType={requiresConfirm ? 'next' : 'done'}
+          blurOnSubmit={!requiresConfirm}
+          onSubmitEditing={handlePassphraseSubmit}
         />
         <Pressable
           style={[styles.passphraseEyeBtn, processing && { opacity: 0.5 }]}
@@ -148,6 +168,9 @@ export function MainAppPassphrasePromptModal({
           <View style={styles.passphraseFieldWrapper}>
             <AppTextInput
               isDark={isDark}
+              ref={(r) => {
+                confirmRef.current = r;
+              }}
               style={[
                 styles.modalInput,
                 styles.passphraseInput,
@@ -164,6 +187,8 @@ export function MainAppPassphrasePromptModal({
               }}
               placeholder="Confirm Passphrase"
               editable={!processing}
+              returnKeyType="done"
+              onSubmitEditing={handleConfirmSubmit}
             />
             <Pressable
               style={[styles.passphraseEyeBtn, processing && { opacity: 0.5 }]}

--- a/frontend/src/features/appShell/hooks/useBlocklistData.ts
+++ b/frontend/src/features/appShell/hooks/useBlocklistData.ts
@@ -13,7 +13,8 @@ function parseApiErrorMessage(raw: string): string {
   if (!t) return '';
   try {
     const parsed: unknown = JSON.parse(t);
-    const rec = typeof parsed === 'object' && parsed != null ? (parsed as Record<string, unknown>) : null;
+    const rec =
+      typeof parsed === 'object' && parsed != null ? (parsed as Record<string, unknown>) : null;
     const msg = rec && typeof rec.message === 'string' ? String(rec.message).trim() : '';
     return msg || t;
   } catch {

--- a/frontend/src/features/appShell/hooks/useLastDmConversation.ts
+++ b/frontend/src/features/appShell/hooks/useLastDmConversation.ts
@@ -1,7 +1,24 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as React from 'react';
 
-export function useLastDmConversation({ conversationId }: { conversationId: string }): {
+function getDeviceStorageKey(): string {
+  // Device-scoped fallback so we can restore before user attrs rehydrate.
+  return 'ui:lastDmConversationId';
+}
+
+function getUserStorageKey(userSub: string | null | undefined): string | null {
+  const u = typeof userSub === 'string' ? userSub.trim() : '';
+  if (!u) return null;
+  return `ui:lastDmConversationId:${u}`;
+}
+
+export function useLastDmConversation({
+  userSub,
+  conversationId,
+}: {
+  userSub?: string | null;
+  conversationId: string;
+}): {
   dmRestoreDone: boolean;
   lastDmConversationIdRef: React.MutableRefObject<string>;
 } {
@@ -12,9 +29,16 @@ export function useLastDmConversation({ conversationId }: { conversationId: stri
   // Note: unlike channels, we do NOT auto-navigate to the last DM on boot.
   React.useEffect(() => {
     let mounted = true;
+    setDmRestoreDone(false);
+    // IMPORTANT: clear immediately so we don't show a previous user's DM label
+    // while async storage loads for the new user.
+    lastDmConversationIdRef.current = '';
     (async () => {
       try {
-        const raw = await AsyncStorage.getItem('ui:lastDmConversationId');
+        const userKey = getUserStorageKey(userSub);
+        const raw =
+          (userKey ? await AsyncStorage.getItem(userKey) : null) ||
+          (await AsyncStorage.getItem(getDeviceStorageKey()));
         const v = typeof raw === 'string' ? raw.trim() : '';
         if (!mounted) return;
         if (v.startsWith('dm#') || v.startsWith('gdm#')) {
@@ -29,7 +53,7 @@ export function useLastDmConversation({ conversationId }: { conversationId: stri
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [userSub]);
 
   // Persist last visited DM/group DM.
   React.useEffect(() => {
@@ -38,12 +62,18 @@ export function useLastDmConversation({ conversationId }: { conversationId: stri
     lastDmConversationIdRef.current = v;
     (async () => {
       try {
-        await AsyncStorage.setItem('ui:lastDmConversationId', v);
+        await AsyncStorage.setItem(getDeviceStorageKey(), v);
+      } catch {
+        // ignore
+      }
+      try {
+        const userKey = getUserStorageKey(userSub);
+        if (userKey) await AsyncStorage.setItem(userKey, v);
       } catch {
         // ignore
       }
     })();
-  }, [conversationId]);
+  }, [conversationId, userSub]);
 
   return { dmRestoreDone, lastDmConversationIdRef };
 }

--- a/frontend/src/features/auth/AuthModalHeaderContext.tsx
+++ b/frontend/src/features/auth/AuthModalHeaderContext.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+type AuthModalHeaderContextValue = {
+  title: string;
+  setTitle: (t: string) => void;
+};
+
+const AuthModalHeaderContext = React.createContext<AuthModalHeaderContextValue | null>(null);
+
+export function AuthModalHeaderProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.JSX.Element {
+  const [title, setTitle] = React.useState('');
+
+  const value = React.useMemo<AuthModalHeaderContextValue>(
+    () => ({
+      title,
+      setTitle,
+    }),
+    [title],
+  );
+
+  return <AuthModalHeaderContext.Provider value={value}>{children}</AuthModalHeaderContext.Provider>;
+}
+
+export function useAuthModalHeader(): AuthModalHeaderContextValue | null {
+  return React.useContext(AuthModalHeaderContext);
+}
+

--- a/frontend/src/features/auth/AuthModalHeaderContext.tsx
+++ b/frontend/src/features/auth/AuthModalHeaderContext.tsx
@@ -22,10 +22,11 @@ export function AuthModalHeaderProvider({
     [title],
   );
 
-  return <AuthModalHeaderContext.Provider value={value}>{children}</AuthModalHeaderContext.Provider>;
+  return (
+    <AuthModalHeaderContext.Provider value={value}>{children}</AuthModalHeaderContext.Provider>
+  );
 }
 
 export function useAuthModalHeader(): AuthModalHeaderContextValue | null {
   return React.useContext(AuthModalHeaderContext);
 }
-

--- a/frontend/src/features/auth/amplifyAuthenticator.tsx
+++ b/frontend/src/features/auth/amplifyAuthenticator.tsx
@@ -1371,9 +1371,43 @@ const ConfirmResetPasswordWithBackToSignIn = ({
   isDark: boolean;
 }): React.JSX.Element => {
   const { toSignIn } = useAuthenticator();
+  const { disableFormSubmit, fieldsWithHandlers, fieldValidationErrors, handleFormSubmit } =
+    useWebAuthFieldValues({
+      componentName: 'ConfirmResetPassword',
+      fields: Array.isArray(props.fields) ? props.fields : [],
+      handleBlur: props.handleBlur,
+      handleChange: props.handleChange,
+      handleSubmit: props.handleSubmit,
+      validationErrors: props.validationErrors,
+    });
+
+  const fieldsSubmitEnhanced = React.useMemo(() => {
+    const arr = Array.isArray(fieldsWithHandlers) ? fieldsWithHandlers : [];
+    return arr.map((f) => {
+      const rec: AmplifyFieldLike =
+        typeof f === 'object' && f != null ? (f as AmplifyFieldLike) : {};
+      const type = String(rec.type ?? '');
+      const name = String(rec.name ?? '');
+      // Only wire submit on the confirm password field.
+      if (type !== 'password') return rec;
+      if (!name.toLowerCase().includes('confirm')) return rec;
+      return {
+        ...rec,
+        returnKeyType: 'go',
+        onSubmitEditing: () => {
+          if (!disableFormSubmit) handleFormSubmit();
+        },
+      } as AmplifyFieldLike;
+    });
+  }, [disableFormSubmit, fieldsWithHandlers, handleFormSubmit]);
+
   return (
     <View>
-      <Authenticator.ConfirmResetPassword {...props} />
+      <Authenticator.ConfirmResetPassword
+        {...props}
+        fields={fieldsSubmitEnhanced}
+        validationErrors={fieldValidationErrors}
+      />
       <AmplifyButton
         onPress={() => toSignIn()}
         variant="link"

--- a/frontend/src/features/chat/buildChatScreenMainProps.ts
+++ b/frontend/src/features/chat/buildChatScreenMainProps.ts
@@ -108,9 +108,11 @@ export function buildChatScreenMainProps(deps: {
   selectionActive: SelectionProps['active'];
   selectionCount: SelectionProps['count'];
   selectionCanCopy: SelectionProps['canCopy'];
+  selectionCanDeleteForEveryone: SelectionProps['canDeleteForEveryone'];
   selectionOnCancel: SelectionProps['onCancel'];
   selectionOnCopy: SelectionProps['onCopy'];
   selectionOnDelete: SelectionProps['onDelete'];
+  selectionOnDeleteForEveryone: SelectionProps['onDeleteForEveryone'];
 }): MainProps {
   return {
     styles: deps.styles,
@@ -213,9 +215,11 @@ export function buildChatScreenMainProps(deps: {
       active: deps.selectionActive,
       count: deps.selectionCount,
       canCopy: deps.selectionCanCopy,
+      canDeleteForEveryone: deps.selectionCanDeleteForEveryone,
       onCancel: deps.selectionOnCancel,
       onCopy: deps.selectionOnCopy,
       onDelete: deps.selectionOnDelete,
+      onDeleteForEveryone: deps.selectionOnDeleteForEveryone,
     },
   };
 }

--- a/frontend/src/features/chat/components/ChannelNameModal.tsx
+++ b/frontend/src/features/chat/components/ChannelNameModal.tsx
@@ -75,6 +75,8 @@ export function ChannelNameModal({
             onChangeText={onChangeDraft}
             placeholder="Channel name"
             maxLength={21}
+            returnKeyType="done"
+            onSubmitEditing={() => void Promise.resolve(onSave())}
             style={{
               width: '100%',
               height: 48,

--- a/frontend/src/features/chat/components/ChannelPasswordModal.tsx
+++ b/frontend/src/features/chat/components/ChannelPasswordModal.tsx
@@ -81,6 +81,8 @@ export function ChannelPasswordModal({
               onChangeText={onChangeDraft}
               placeholder="Password"
               secureTextEntry={!passwordVisible}
+              returnKeyType="done"
+              onSubmitEditing={() => void Promise.resolve(onSave())}
               style={{
                 width: '100%',
                 height: 48,

--- a/frontend/src/features/chat/components/ChannelPasswordModal.tsx
+++ b/frontend/src/features/chat/components/ChannelPasswordModal.tsx
@@ -1,5 +1,6 @@
+import { icons } from '@aws-amplify/ui-react-native/dist/assets';
 import React from 'react';
-import { Modal, Platform, Pressable, Text, View } from 'react-native';
+import { Image, Modal, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { AppTextInput } from '../../../components/AppTextInput';
 import {
@@ -7,7 +8,7 @@ import {
   useKeyboardOverlap,
 } from '../../../hooks/useKeyboardOverlap';
 import type { ChatScreenStyles } from '../../../screens/ChatScreen.styles';
-import { APP_COLORS } from '../../../theme/colors';
+import { APP_COLORS, PALETTE } from '../../../theme/colors';
 
 type Props = {
   visible: boolean;
@@ -31,6 +32,10 @@ export function ChannelPasswordModal({
   onCancel,
 }: Props) {
   const kb = useKeyboardOverlap({ enabled: visible });
+  const [passwordVisible, setPasswordVisible] = React.useState<boolean>(false);
+  React.useEffect(() => {
+    if (!visible) setPasswordVisible(false);
+  }, [visible]);
   const [sheetHeight, setSheetHeight] = React.useState<number>(0);
   const bottomPad = React.useMemo(
     () =>
@@ -67,29 +72,49 @@ export function ChannelPasswordModal({
           }}
         >
           <Text style={[styles.summaryTitle, isDark ? styles.summaryTitleDark : null]}>
-            Channel Password
+            Set Channel Password
           </Text>
-          <AppTextInput
-            isDark={isDark}
-            value={draft}
-            onChangeText={onChangeDraft}
-            placeholder="Password"
-            secureTextEntry
-            style={{
-              width: '100%',
-              height: 48,
-              paddingHorizontal: 12,
-              borderWidth: 1,
-              borderRadius: 10,
-              marginTop: 10,
-              backgroundColor: isDark ? APP_COLORS.dark.bg.header : APP_COLORS.light.bg.surface2,
-              borderColor: isDark ? APP_COLORS.dark.border.default : APP_COLORS.light.border.subtle,
-              color: isDark ? APP_COLORS.dark.text.primary : APP_COLORS.light.text.primary,
-              fontSize: 16,
-            }}
-            editable
-            autoFocus
-          />
+          <View style={{ width: '100%', marginTop: 10 }}>
+            <AppTextInput
+              isDark={isDark}
+              value={draft}
+              onChangeText={onChangeDraft}
+              placeholder="Password"
+              secureTextEntry={!passwordVisible}
+              style={{
+                width: '100%',
+                height: 48,
+                paddingHorizontal: 12,
+                paddingRight: 44, // space for the eye button
+                borderWidth: 1,
+                borderRadius: 10,
+                backgroundColor: isDark ? APP_COLORS.dark.bg.header : APP_COLORS.light.bg.surface2,
+                borderColor: isDark
+                  ? APP_COLORS.dark.border.default
+                  : APP_COLORS.light.border.subtle,
+                color: isDark ? APP_COLORS.dark.text.primary : APP_COLORS.light.text.primary,
+                fontSize: 16,
+              }}
+              editable
+              autoFocus
+            />
+            <Pressable
+              style={({ pressed }) => [
+                s.eyeBtn,
+                busy ? { opacity: 0.45 } : pressed ? { opacity: 0.85 } : null,
+              ]}
+              onPress={() => setPasswordVisible((v) => !v)}
+              disabled={busy}
+              accessibilityRole="button"
+              accessibilityLabel={passwordVisible ? 'Hide password' : 'Show password'}
+            >
+              <Image
+                source={passwordVisible ? icons.visibilityOn : icons.visibilityOff}
+                tintColor={isDark ? PALETTE.slate400 : PALETTE.slate450}
+                style={{ width: 18, height: 18 }}
+              />
+            </Pressable>
+          </View>
           <View style={styles.summaryButtons}>
             <Pressable
               style={[
@@ -123,3 +148,15 @@ export function ChannelPasswordModal({
     </Modal>
   );
 }
+
+const s = StyleSheet.create({
+  eyeBtn: {
+    position: 'absolute',
+    right: 10,
+    top: 0,
+    height: 48,
+    width: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/frontend/src/features/chat/components/ChannelSettingsPanel.tsx
+++ b/frontend/src/features/chat/components/ChannelSettingsPanel.tsx
@@ -67,6 +67,441 @@ type Props = {
   onPressPassword: () => void;
 };
 
+type WideProps = Omit<Props, 'compact'>;
+
+type WidePlacement = {
+  shouldWrap: boolean;
+  clusterLeft?: number;
+};
+
+type WideLayoutMode = 'overlay_both' | 'overlay_visibility_only' | 'wrap_all';
+
+type WideLayoutDecision = {
+  mode: WideLayoutMode;
+  clusterLeft?: number;
+};
+
+function WideChannelSettingsPanel({
+  isDark,
+  styles,
+  busy,
+  meIsAdmin,
+  isPublic,
+  hasPassword,
+  membersCountLabel,
+  onOpenMembers,
+  onOpenAbout,
+  onOpenName,
+  onLeave,
+  onTogglePublic,
+  onPressPassword,
+}: WideProps) {
+  // Measure *content* widths (not flex slot widths) so we only wrap when the
+  // actual controls would collide.
+  const [wideLayout, setWideLayout] = React.useState<{
+    containerW: number;
+    membersActualW: number;
+    visibilityW: number;
+    passwordW: number;
+    actionsActualW: number;
+  }>({
+    containerW: 0,
+    membersActualW: 0,
+    visibilityW: 0,
+    passwordW: 0,
+    actionsActualW: 0,
+  });
+
+  const setIfChanged = React.useCallback(
+    (
+      key: 'containerW' | 'membersActualW' | 'visibilityW' | 'passwordW' | 'actionsActualW',
+      w: number,
+    ) => {
+      if (!(w > 0) || !Number.isFinite(w)) return;
+      setWideLayout((prev) => {
+        const prevW = prev[key];
+        if (Math.abs(prevW - w) < 1) return prev;
+        return { ...prev, [key]: w };
+      });
+    },
+    [],
+  );
+
+  const hasPasswordControl = meIsAdmin ? !!isPublic : !!(isPublic && hasPassword);
+  const memberPasswordProtected = !meIsAdmin && isPublic && hasPasswordControl;
+
+  // If the password control disappears, clear the cached width so we don't
+  // keep wrapping based on stale measurements.
+  React.useEffect(() => {
+    if (hasPasswordControl) return;
+    setWideLayout((prev) => (prev.passwordW === 0 ? prev : { ...prev, passwordW: 0 }));
+  }, [hasPasswordControl]);
+
+  // Decide what to keep on the top row:
+  // - Prefer keeping BOTH (Visibility + Password) up if possible
+  // - Otherwise keep Visibility up and move Password to row 2
+  // - Otherwise wrap both to row 2
+  const wideDecision = React.useMemo<WideLayoutDecision>(() => {
+    const { containerW, membersActualW, actionsActualW, visibilityW, passwordW } = wideLayout;
+    if (!(containerW > 0 && visibilityW > 0)) {
+      return { mode: 'overlay_both' };
+    }
+
+    // The overlay is absolutely positioned; don't reserve extra space here.
+    // We want wrapping to happen only when we truly cannot place the control
+    // anywhere without overlapping.
+    const leftGap = 8; // keep a little space from Members chip
+    const rightGap = 4; // small buffer from right-side actions
+
+    // Use the *actual* rendered widths from the real row (post-flex/truncation),
+    // not the hidden "intrinsic" widths. This avoids wrapping too early when
+    // there's still plenty of space.
+    const membersEffW = membersActualW;
+    const actionsEffW = actionsActualW;
+
+    const computePlacement = (w: number): WidePlacement => {
+      if (!(w > 0)) return { shouldWrap: false };
+      const minCenter = membersEffW + leftGap + w / 2;
+      const maxCenter = containerW - actionsEffW - rightGap - w / 2;
+      if (minCenter > maxCenter) return { shouldWrap: true };
+
+      const desiredCenter = containerW / 2;
+      const clampedCenter = Math.min(Math.max(desiredCenter, minCenter), maxCenter);
+      const left = Math.min(Math.max(0, clampedCenter - w / 2), Math.max(0, containerW - w));
+      return { shouldWrap: false, clusterLeft: left };
+    };
+
+    const passwordSpacing = hasPasswordControl ? 10 : 0;
+    const bothW = visibilityW + (hasPasswordControl ? passwordSpacing + passwordW : 0);
+
+    // 1) Try keeping the whole cluster up (Visibility + Password)
+    const both = computePlacement(bothW);
+    if (!both.shouldWrap) return { mode: 'overlay_both', clusterLeft: both.clusterLeft };
+
+    // If this is the member "Password Protected" chip, keep it paired with
+    // Public/Private: if one drops, both drop.
+    if (memberPasswordProtected) return { mode: 'wrap_all' };
+
+    // 2) Otherwise keep Visibility up (and let Password drop)
+    const vis = computePlacement(visibilityW);
+    if (!vis.shouldWrap) return { mode: 'overlay_visibility_only', clusterLeft: vis.clusterLeft };
+
+    // 3) Last resort: wrap all controls down
+    return { mode: 'wrap_all' };
+  }, [hasPasswordControl, memberPasswordProtected, wideLayout]);
+
+  const visibilityControl = (
+    <View style={styles.dmSettingGroup}>
+      {meIsAdmin ? (
+        <>
+          <Text
+            style={[
+              styles.decryptLabel,
+              isDark ? styles.decryptLabelDark : null,
+              styles.dmSettingLabel,
+            ]}
+            numberOfLines={1}
+          >
+            Visibility
+          </Text>
+          {Platform.OS === 'web' ? (
+            <MiniToggle
+              value={!!isPublic}
+              disabled={busy}
+              isDark={isDark}
+              styles={styles}
+              onValueChange={onTogglePublic}
+            />
+          ) : (
+            <Switch
+              value={!!isPublic}
+              disabled={busy}
+              onValueChange={onTogglePublic}
+              trackColor={{
+                false: APP_COLORS.light.border.default,
+                true: APP_COLORS.light.border.default,
+              }}
+              thumbColor={isDark ? APP_COLORS.dark.border.subtle : APP_COLORS.light.bg.app}
+              ios_backgroundColor={APP_COLORS.light.border.default}
+            />
+          )}
+          <Text
+            style={[
+              styles.decryptLabel,
+              isDark ? styles.decryptLabelDark : null,
+              styles.dmSettingLabel,
+              { fontWeight: '900' },
+            ]}
+            numberOfLines={1}
+          >
+            {isPublic ? 'Public' : 'Private'}
+          </Text>
+        </>
+      ) : (
+        <Text
+          style={[
+            styles.decryptLabel,
+            isDark ? styles.decryptLabelDark : null,
+            styles.dmSettingLabel,
+          ]}
+          numberOfLines={1}
+        >
+          {isPublic ? 'Public' : 'Private'}
+        </Text>
+      )}
+    </View>
+  );
+
+  const passwordControl =
+    meIsAdmin && isPublic ? (
+      <Pressable
+        style={[styles.toolBtn, isDark ? styles.toolBtnDark : null, busy ? { opacity: 0.6 } : null]}
+        disabled={busy}
+        onPress={onPressPassword}
+      >
+        <View
+          style={{ flexDirection: 'row', alignItems: 'center', gap: 6, flexShrink: 1, minWidth: 0 }}
+        >
+          <Feather
+            name={hasPassword ? 'lock' : 'unlock'}
+            size={14}
+            color={isDark ? APP_COLORS.dark.text.primary : APP_COLORS.light.text.primary}
+          />
+          <Text
+            style={[
+              styles.toolBtnText,
+              isDark ? styles.toolBtnTextDark : null,
+              { flexShrink: 1, minWidth: 0 },
+            ]}
+            numberOfLines={1}
+            ellipsizeMode="tail"
+          >
+            {hasPassword ? 'Password: On' : 'Password: Off'}
+          </Text>
+        </View>
+      </Pressable>
+    ) : !meIsAdmin && isPublic && hasPassword ? (
+      <View style={[styles.toolBtn, isDark ? styles.toolBtnDark : null, { maxWidth: '100%' }]}>
+        <View
+          style={{ flexDirection: 'row', alignItems: 'center', gap: 6, flexShrink: 1, minWidth: 0 }}
+        >
+          <Feather
+            name="lock"
+            size={14}
+            color={isDark ? APP_COLORS.dark.text.primary : APP_COLORS.light.text.primary}
+          />
+          <Text
+            style={[
+              styles.toolBtnText,
+              isDark ? styles.toolBtnTextDark : null,
+              { flexShrink: 1, minWidth: 0 },
+            ]}
+            numberOfLines={1}
+          >
+            Password Protected
+          </Text>
+        </View>
+      </View>
+    ) : null;
+
+  const MembersControl = ({ onLayout }: { onLayout?: (w: number) => void }) => (
+    <View
+      style={styles.dmSettingGroup}
+      onLayout={onLayout ? (e) => onLayout(Number(e?.nativeEvent?.layout?.width ?? 0)) : undefined}
+    >
+      <Text
+        style={[
+          styles.decryptLabel,
+          isDark ? styles.decryptLabelDark : null,
+          styles.dmSettingLabel,
+        ]}
+        numberOfLines={1}
+      >
+        Members
+      </Text>
+      <Pressable
+        style={[styles.toolBtn, isDark ? styles.toolBtnDark : null, busy ? { opacity: 0.6 } : null]}
+        accessibilityRole="button"
+        accessibilityLabel="Members"
+        disabled={busy}
+        onPress={onOpenMembers}
+      >
+        <Text style={[styles.toolBtnText, isDark ? styles.toolBtnTextDark : null]}>
+          {membersCountLabel}
+        </Text>
+      </Pressable>
+    </View>
+  );
+
+  const ClusterControl = ({ onLayout }: { onLayout?: (w: number) => void }) => (
+    <View
+      style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'center' }}
+      onLayout={onLayout ? (e) => onLayout(Number(e?.nativeEvent?.layout?.width ?? 0)) : undefined}
+    >
+      {visibilityControl}
+      {passwordControl ? <View style={{ marginLeft: 10 }}>{passwordControl}</View> : null}
+    </View>
+  );
+
+  const VisibilityOnlyControl = ({ onLayout }: { onLayout?: (w: number) => void }) => (
+    <View
+      onLayout={onLayout ? (e) => onLayout(Number(e?.nativeEvent?.layout?.width ?? 0)) : undefined}
+    >
+      {visibilityControl}
+    </View>
+  );
+
+  const PasswordOnlyControl = ({ onLayout }: { onLayout?: (w: number) => void }) =>
+    passwordControl ? (
+      <View
+        onLayout={
+          onLayout ? (e) => onLayout(Number(e?.nativeEvent?.layout?.width ?? 0)) : undefined
+        }
+      >
+        {passwordControl}
+      </View>
+    ) : null;
+
+  const ActionsControl = ({ onLayout }: { onLayout?: (w: number) => void }) => (
+    <View
+      style={[styles.channelAdminActions, { justifyContent: 'flex-end', marginLeft: 0 }]}
+      onLayout={onLayout ? (e) => onLayout(Number(e?.nativeEvent?.layout?.width ?? 0)) : undefined}
+    >
+      {meIsAdmin ? (
+        <Pressable
+          style={[
+            styles.toolBtn,
+            isDark ? styles.toolBtnDark : null,
+            busy ? { opacity: 0.6 } : null,
+          ]}
+          disabled={busy}
+          onPress={onOpenAbout}
+        >
+          <Text style={[styles.toolBtnText, isDark ? styles.toolBtnTextDark : null]}>About</Text>
+        </Pressable>
+      ) : null}
+
+      {meIsAdmin ? (
+        <Pressable
+          style={[
+            styles.toolBtn,
+            isDark ? styles.toolBtnDark : null,
+            busy ? { opacity: 0.6 } : null,
+            { marginLeft: 10 },
+          ]}
+          disabled={busy}
+          onPress={onOpenName}
+        >
+          <Text style={[styles.toolBtnText, isDark ? styles.toolBtnTextDark : null]}>Name</Text>
+        </Pressable>
+      ) : null}
+
+      <Pressable
+        style={[
+          styles.toolBtn,
+          isDark ? styles.toolBtnDark : null,
+          busy ? { opacity: 0.6 } : null,
+          { marginLeft: 10 },
+        ]}
+        disabled={busy}
+        onPress={onLeave}
+      >
+        <Text style={[styles.toolBtnText, isDark ? styles.toolBtnTextDark : null]}>Leave</Text>
+      </Pressable>
+    </View>
+  );
+
+  return (
+    <View
+      style={styles.channelAdminPanel}
+      onLayout={(e) => setIfChanged('containerW', Number(e?.nativeEvent?.layout?.width ?? 0))}
+    >
+      {/* Hidden measurement row (intrinsic widths, no flex). */}
+      <View
+        pointerEvents="none"
+        style={{ position: 'absolute', opacity: 0, left: 0, top: 0, flexDirection: 'row' }}
+      >
+        <View style={{ marginLeft: 10 }}>
+          <VisibilityOnlyControl onLayout={(w) => setIfChanged('visibilityW', w)} />
+        </View>
+        <View style={{ marginLeft: 10 }}>
+          <PasswordOnlyControl onLayout={(w) => setIfChanged('passwordW', w)} />
+        </View>
+      </View>
+
+      {wideDecision.mode === 'wrap_all' ? (
+        <>
+          <View style={styles.channelAdminRow}>
+            <View style={{ flex: 1, alignItems: 'flex-start', minWidth: 0 }}>
+              <MembersControl onLayout={(w) => setIfChanged('membersActualW', w)} />
+            </View>
+            <View style={{ flex: 1, alignItems: 'flex-end', minWidth: 0 }}>
+              <ActionsControl onLayout={(w) => setIfChanged('actionsActualW', w)} />
+            </View>
+          </View>
+          {memberPasswordProtected ? (
+            <View style={[styles.channelAdminRow, { marginTop: 8, flexWrap: 'wrap' }]}>
+              <View style={{ marginRight: 10 }}>{visibilityControl}</View>
+              {passwordControl ? <View style={{ marginLeft: 10 }}>{passwordControl}</View> : null}
+            </View>
+          ) : (
+            <View style={[styles.channelAdminRow, { marginTop: 8 }]}>
+              <View style={{ flex: 1, alignItems: 'flex-start', minWidth: 0 }}>
+                {visibilityControl}
+              </View>
+              <View style={{ flex: 1 }} />
+              <View style={{ flex: 1, alignItems: 'flex-end', minWidth: 0 }}>
+                {passwordControl}
+              </View>
+            </View>
+          )}
+        </>
+      ) : (
+        <>
+          <View style={[styles.channelAdminRow, { position: 'relative' }]}>
+            <View style={{ flex: 1, alignItems: 'flex-start', minWidth: 0 }}>
+              <MembersControl onLayout={(w) => setIfChanged('membersActualW', w)} />
+            </View>
+
+            {/* Overlay (slides left/right) */}
+            <View
+              pointerEvents="box-none"
+              style={{
+                position: 'absolute',
+                left: wideDecision.clusterLeft,
+                top: 0,
+                bottom: 0,
+                justifyContent: 'center',
+              }}
+            >
+              {wideDecision.mode === 'overlay_both' ? (
+                <ClusterControl />
+              ) : (
+                <VisibilityOnlyControl />
+              )}
+            </View>
+
+            <View style={{ flex: 1, alignItems: 'flex-end', minWidth: 0 }}>
+              <ActionsControl onLayout={(w) => setIfChanged('actionsActualW', w)} />
+            </View>
+          </View>
+
+          {/* If only Visibility fits up top, put Password on row 2. */}
+          {wideDecision.mode === 'overlay_visibility_only' && passwordControl ? (
+            <View style={[styles.channelAdminRow, { marginTop: 8 }]}>
+              <View style={{ flex: 1 }} />
+              <View style={{ flex: 1 }} />
+              <View style={{ flex: 1, alignItems: 'flex-end', minWidth: 0 }}>
+                {passwordControl}
+              </View>
+            </View>
+          ) : null}
+        </>
+      )}
+    </View>
+  );
+}
+
 export function ChannelSettingsPanel({
   isDark,
   styles,
@@ -83,6 +518,28 @@ export function ChannelSettingsPanel({
   onTogglePublic,
   onPressPassword,
 }: Props) {
+  // Wide screens: merge Visibility + Password into the same row as channel options.
+  // Small screens: keep the current two-row layout (less crowded, better wrapping).
+  if (!compact) {
+    return (
+      <WideChannelSettingsPanel
+        isDark={isDark}
+        styles={styles}
+        busy={busy}
+        meIsAdmin={meIsAdmin}
+        isPublic={isPublic}
+        hasPassword={hasPassword}
+        membersCountLabel={membersCountLabel}
+        onOpenMembers={onOpenMembers}
+        onOpenAbout={onOpenAbout}
+        onOpenName={onOpenName}
+        onLeave={onLeave}
+        onTogglePublic={onTogglePublic}
+        onPressPassword={onPressPassword}
+      />
+    );
+  }
+
   return (
     <View style={[styles.channelAdminPanel, compact ? { rowGap: 8 } : null]}>
       {/* Row 1: Members + (About/Name/Leave) */}
@@ -232,7 +689,7 @@ export function ChannelSettingsPanel({
               ]}
               numberOfLines={1}
             >
-              {`Visibility: ${isPublic ? 'Public' : 'Private'}`}
+              {isPublic ? 'Public' : 'Private'}
             </Text>
           )}
         </View>
@@ -248,13 +705,29 @@ export function ChannelSettingsPanel({
               disabled={busy}
               onPress={onPressPassword}
             >
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+              <View
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  gap: 6,
+                  flexShrink: 1,
+                  minWidth: 0,
+                }}
+              >
                 <Feather
                   name={hasPassword ? 'lock' : 'unlock'}
                   size={14}
                   color={isDark ? APP_COLORS.dark.text.primary : APP_COLORS.light.text.primary}
                 />
-                <Text style={[styles.toolBtnText, isDark ? styles.toolBtnTextDark : null]}>
+                <Text
+                  style={[
+                    styles.toolBtnText,
+                    isDark ? styles.toolBtnTextDark : null,
+                    { flexShrink: 1, minWidth: 0 },
+                  ]}
+                  numberOfLines={1}
+                  ellipsizeMode="tail"
+                >
                   {compact ? 'Password' : hasPassword ? 'Password: On' : 'Password: Off'}
                 </Text>
               </View>

--- a/frontend/src/features/chat/components/ChannelSettingsPanel.tsx
+++ b/frontend/src/features/chat/components/ChannelSettingsPanel.tsx
@@ -191,7 +191,7 @@ function WideChannelSettingsPanel({
   }, [hasPasswordControl, memberPasswordProtected, wideLayout]);
 
   const visibilityControl = (
-    <View style={styles.dmSettingGroup}>
+    <View style={[styles.dmSettingGroup, { flexShrink: 0 }]}>
       {meIsAdmin ? (
         <>
           <Text
@@ -199,6 +199,7 @@ function WideChannelSettingsPanel({
               styles.decryptLabel,
               isDark ? styles.decryptLabelDark : null,
               styles.dmSettingLabel,
+              { flexShrink: 0 },
             ]}
             numberOfLines={1}
           >
@@ -231,6 +232,7 @@ function WideChannelSettingsPanel({
               isDark ? styles.decryptLabelDark : null,
               styles.dmSettingLabel,
               { fontWeight: '900' },
+              { flexShrink: 0 },
             ]}
             numberOfLines={1}
           >
@@ -243,6 +245,7 @@ function WideChannelSettingsPanel({
             styles.decryptLabel,
             isDark ? styles.decryptLabelDark : null,
             styles.dmSettingLabel,
+            { flexShrink: 0 },
           ]}
           numberOfLines={1}
         >

--- a/frontend/src/features/chat/components/ChatMessageRow.tsx
+++ b/frontend/src/features/chat/components/ChatMessageRow.tsx
@@ -243,6 +243,9 @@ export function ChatMessageRow(props: {
           styles.messageRow,
           isOutgoing ? styles.messageRowOutgoing : styles.messageRowIncoming,
           selectionActive ? { paddingLeft: 34 } : null,
+          // Reaction chips are positioned slightly below the bubble.
+          // Add bottom padding so the next message doesn't visually overlap them.
+          reactionEntriesVisible.length ? { paddingBottom: 12 } : null,
         ]}
       >
         {selectionActive ? (

--- a/frontend/src/features/chat/components/ChatScreenMain.tsx
+++ b/frontend/src/features/chat/components/ChatScreenMain.tsx
@@ -155,9 +155,11 @@ type ChatScreenMainProps = {
     active: boolean;
     count: number;
     canCopy: boolean;
+    canDeleteForEveryone: boolean;
     onCancel: () => void;
     onCopy: () => void;
     onDelete: () => void;
+    onDeleteForEveryone: () => void;
   };
 };
 
@@ -468,6 +470,29 @@ export function ChatScreenMain({
                         }}
                       >
                         Copy
+                      </Text>
+                    </Pressable>
+                  ) : null}
+
+                  {selection.canDeleteForEveryone ? (
+                    <Pressable
+                      onPress={selection.onDeleteForEveryone}
+                      style={({ pressed }) => [
+                        { height: 44, justifyContent: 'center', paddingHorizontal: 10 },
+                        pressed ? { opacity: 0.85 } : null,
+                      ]}
+                      accessibilityRole="button"
+                      accessibilityLabel="Delete selected messages for everyone"
+                    >
+                      <Text
+                        style={{
+                          color: isDark
+                            ? APP_COLORS.dark.text.primary
+                            : APP_COLORS.light.text.primary,
+                          fontWeight: '900',
+                        }}
+                      >
+                        Delete for everyone
                       </Text>
                     </Pressable>
                   ) : null}

--- a/frontend/src/features/chat/components/ChatScreenMain.tsx
+++ b/frontend/src/features/chat/components/ChatScreenMain.tsx
@@ -350,7 +350,7 @@ export function ChatScreenMain({
               <ChannelSettingsPanel
                 isDark={isDark}
                 styles={styles}
-                compact={!!header.dmSettingsCompact}
+                compact={false}
                 busy={!!header.channelBusy}
                 meIsAdmin={!!header.channelMeIsAdmin}
                 isPublic={!!header.channelIsPublic}

--- a/frontend/src/features/chat/components/GroupNameModal.tsx
+++ b/frontend/src/features/chat/components/GroupNameModal.tsx
@@ -77,6 +77,8 @@ export function GroupNameModal({
             onChangeText={onChangeDraft}
             placeholder="Group name"
             maxLength={20}
+            returnKeyType="done"
+            onSubmitEditing={() => void Promise.resolve(onSave())}
             // Use a fully explicit style here (avoid theme/style collisions in Android modals).
             style={{
               width: '100%',

--- a/frontend/src/features/chat/renderChatListItem.tsx
+++ b/frontend/src/features/chat/renderChatListItem.tsx
@@ -294,6 +294,20 @@ export function renderChatListItem(args: {
 
   // NOTE: This file is a render helper, not a React component, so we MUST NOT use hooks here.
 
+  const handleOpenMessageActionsFromEvent = (e: unknown) => {
+    if (!e || typeof e !== 'object') {
+      openMessageActions(item, { x: 0, y: 0 });
+      return;
+    }
+    const ne = (e as Record<string, unknown>).nativeEvent;
+    const neRec = ne && typeof ne === 'object' ? (ne as Record<string, unknown>) : {};
+    const xRaw = Platform.OS === 'web' ? (neRec.clientX ?? neRec.pageX ?? 0) : (neRec.pageX ?? 0);
+    const yRaw = Platform.OS === 'web' ? (neRec.clientY ?? neRec.pageY ?? 0) : (neRec.pageY ?? 0);
+    const x = Number(xRaw) || 0;
+    const y = Number(yRaw) || 0;
+    openMessageActions(item, { x, y });
+  };
+
   const openFileAtOriginalIdx = (originalIdx: number) => {
     if (isDm) return void openDmMediaViewer(item, originalIdx);
     if (isGroup) return void openGroupMediaViewer(item, originalIdx);
@@ -390,6 +404,7 @@ export function renderChatListItem(args: {
           else if (isGroup) void openGroupMediaViewer(item, originalIdx);
           else openViewer(mediaList, originalIdx);
         }}
+        onLongPress={(e) => handleOpenMessageActionsFromEvent(e)}
       />
     ) : null;
 
@@ -455,6 +470,7 @@ export function renderChatListItem(args: {
               isDark={isDark}
               isOutgoing={isOutgoing}
               onPress={() => openFileAtOriginalIdx(idx2)}
+              onLongPress={(e) => handleOpenMessageActionsFromEvent(e)}
               onDownload={
                 !isEncryptedChat && mediaUrlByPath[String(m2.path)]
                   ? () =>
@@ -525,21 +541,7 @@ export function renderChatListItem(args: {
       openGroupMediaViewer={openGroupMediaViewer}
       requestOpenLink={requestOpenLink}
       onPressMessage={onPressMessage}
-      onLongPressMessage={(e: unknown) => {
-        if (!e || typeof e !== 'object') {
-          openMessageActions(item, { x: 0, y: 0 });
-          return;
-        }
-        const ne = (e as Record<string, unknown>).nativeEvent;
-        const neRec = ne && typeof ne === 'object' ? (ne as Record<string, unknown>) : {};
-        const xRaw =
-          Platform.OS === 'web' ? (neRec.clientX ?? neRec.pageX ?? 0) : (neRec.pageX ?? 0);
-        const yRaw =
-          Platform.OS === 'web' ? (neRec.clientY ?? neRec.pageY ?? 0) : (neRec.pageY ?? 0);
-        const x = Number(xRaw) || 0;
-        const y = Number(yRaw) || 0;
-        openMessageActions(item, { x, y });
-      }}
+      onLongPressMessage={(e: unknown) => handleOpenMessageActionsFromEvent(e)}
       selectionActive={selectionActive}
       isSelected={selectedIdSet.has(String(item.id))}
       onToggleSelected={() => toggleSelectedMessageId(String(item.id))}

--- a/frontend/src/features/guest/components/GuestMessageRow.tsx
+++ b/frontend/src/features/guest/components/GuestMessageRow.tsx
@@ -252,7 +252,7 @@ export function GuestMessageRow({
       </Text>
     </View>
   ) : (
-    <View style={[styles.msgRow]}>
+    <View style={[styles.msgRow, reactionEntriesVisible.length ? { paddingBottom: 12 } : null]}>
       {showAvatar ? (
         <View style={[styles.avatarGutter, { width: avatarSize, marginTop: AVATAR_TOP_OFFSET }]}>
           <AvatarBubble
@@ -680,11 +680,15 @@ const styles = StyleSheet.create({
     right: 10,
     flexDirection: 'row',
     alignItems: 'center',
+    // Ensure chips float above adjacent rows/messages.
+    zIndex: 10,
+    elevation: 10,
   },
   guestReactionChip: {
     borderRadius: 999,
-    paddingHorizontal: 6,
-    paddingVertical: 3,
+    // Keep emoji/text size the same, but tighten the chip chrome.
+    paddingHorizontal: 2,
+    paddingVertical: 2,
     backgroundColor: APP_COLORS.light.bg.app,
     borderWidth: StyleSheet.hairlineWidth,
     borderColor: APP_COLORS.light.border.subtle,

--- a/frontend/src/screens/ChatScreen.styles.ts
+++ b/frontend/src/screens/ChatScreen.styles.ts
@@ -1248,6 +1248,9 @@ export const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 0,
+    // Ensure reaction chips render above adjacent rows/messages.
+    zIndex: 10,
+    elevation: 10,
   },
   // Always anchor reaction chips to the right edge (incoming + outgoing),
   // so they line up consistently with the sender-side layout.
@@ -1274,8 +1277,9 @@ export const styles = StyleSheet.create({
   },
   reactionMiniChip: {
     borderRadius: 999,
-    paddingHorizontal: 6,
-    paddingVertical: 3,
+    // Keep emoji/text size the same, but tighten the chip chrome.
+    paddingHorizontal: 2,
+    paddingVertical: 2,
     backgroundColor: APP_COLORS.light.bg.surface2,
     borderWidth: StyleSheet.hairlineWidth,
     borderColor: APP_COLORS.light.border.subtle,

--- a/frontend/src/screens/ChatScreen.tsx
+++ b/frontend/src/screens/ChatScreen.tsx
@@ -613,6 +613,30 @@ export default function ChatScreen({
   );
   const isEncryptedChat = isDm || isGroup;
 
+  // If we restore into a conversation we can no longer access (banned/kicked/unauthorized),
+  // default back to Global without prompting.
+  // - For live kicks, WS already emits {type:'kicked'} which routes through onKickedFromConversation.
+  // - For boot-time restore, the HTTP history fetch often provides the first clear 401/403 signal.
+  const lastAccessDeniedConvRef = React.useRef<string>('');
+  React.useEffect(() => {
+    const cid = String(activeConversationId || '').trim() || 'global';
+    if (!(cid.startsWith('ch#') || cid.startsWith('gdm#'))) return;
+    const msg = String(error || '').trim();
+    if (!msg) return;
+    const m = msg.toLowerCase();
+    const looksLikeDenied =
+      (m.includes('history fetch failed') && (m.includes('(403)') || m.includes('(401)'))) ||
+      (/\bhistory fetch failed\b/.test(m) && (/\b403\b/.test(m) || /\b401\b/.test(m)));
+    if (!looksLikeDenied) return;
+    if (lastAccessDeniedConvRef.current === cid) return;
+    lastAccessDeniedConvRef.current = cid;
+    try {
+      onKickedFromConversationRef.current?.(cid);
+    } catch {
+      // ignore
+    }
+  }, [activeConversationId, error]);
+
   const groupMembersCountLabel = React.useMemo(() => {
     if (!isGroup) return '-';
     // Until roster hydrates, avoid flashing "0" (group always has at least 1 member once loaded).


### PR DESCRIPTION
Guests have Home Channel now

Home Channel/Home DM/Last Conversation is now tied per user locally. This allows multiple users on the same device to have their home Channel/Home DM/Last Conversation persist. 

Proper fallback for guests - if channel set to private/password, guests are kicked out silently, and revert to Home

Proper fallback for signed in - if banned from channel, silently fall back to global. If banned from Group DM, they see the historic chat and the note at bottom saying they were banned and are read-only.

Set Channel Password now has hide/show

Long Press on full message bubble for message options (previously long pressing on media did not pull up message options, only the top text tile would respond to this)

Swiping on Audio Tiles in Multi-Media in mobile sometimes not responsive, fixed by setting a swipe zone outside audio tile (to not interfere with swipe behavior on the audio playback position)

Focus on Auth fields with password to include entire text input field, rather than cutting short before the show/hide password

Remove multiple labels on auth forms (Sign in, Sign in), web space below password

Reaction chips always on top (not covered by next message in chat), and reduce padding around icon

Delete for Everyone option on selecting multiple messages if you select your own messages only, with confirmation

Make Enter/return submit on last field in Auth Forms for mobile and web

Merging Advanced channel details for large screens

AutoDecrypt not covered when screen goes very small in Group DMs

Enter/return submits on start DM, Blocklist, Channel Password, Enter Passphrase, Change recovery passphrase, Set Group Name, Set Channel name, Set Channel Password, Enter Channel Password, 

Trying to block yourself shows clientside error rejection
