### PR TITLE
npm cleanup

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,6 +1,5 @@
 module.exports = {
   preset: 'jest-expo',
   testMatch: ['**/?(*.)+(test).[tj]s?(x)'],
-  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   testPathIgnorePatterns: ['/node_modules/', '/dist/'],
 };

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,1 +1,1 @@
-import '@testing-library/jest-native/extend-expect';
+// React Native Testing Library (v12.4+) provides built-in Jest matchers.

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,1 +1,0 @@
-// React Native Testing Library (v12.4+) provides built-in Jest matchers.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -63,7 +63,6 @@
         "@aws-amplify/backend": "^1.18.0",
         "@aws-amplify/backend-cli": "^1.8.0",
         "@babel/core": "^7.25.2",
-        "@testing-library/jest-native": "^5.4.3",
         "@testing-library/react-native": "^13.3.3",
         "@types/jest": "^29.5.14",
         "@types/react": "^19.2.4",
@@ -57288,26 +57287,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@testing-library/jest-native": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-native/-/jest-native-5.4.3.tgz",
-      "integrity": "sha512-/sSDGaOuE+PJ1Z9Kp4u7PQScSVVXGud59I/qsBFFJvIbcn4P6yYw6cBnBmbPF+X9aRIsTJRDl6gzw5ZkJNm66w==",
-      "deprecated": "DEPRECATED: This package is no longer maintained.\nPlease use the built-in Jest matchers available in @testing-library/react-native v12.4+.\n\nSee migration guide: https://callstack.github.io/react-native-testing-library/docs/migration/jest-matchers",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "jest-diff": "^29.0.1",
-        "jest-matcher-utils": "^29.0.1",
-        "pretty-format": "^29.0.3",
-        "redent": "^3.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.0.0",
-        "react-native": ">=0.59",
-        "react-test-renderer": ">=16.0.0"
       }
     },
     "node_modules/@testing-library/react-native": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -74,7 +74,6 @@
     "@aws-amplify/backend": "^1.18.0",
     "@aws-amplify/backend-cli": "^1.8.0",
     "@babel/core": "^7.25.2",
-    "@testing-library/jest-native": "^5.4.3",
     "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^29.5.14",
     "@types/react": "^19.2.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -71,7 +71,7 @@
     "react-native-web": "^0.21.0"
   },
   "devDependencies": {
-    "@aws-amplify/backend": "^1.18.0",
+    "@aws-amplify/backend": "^1.20.0",
     "@aws-amplify/backend-cli": "^1.8.0",
     "@babel/core": "^7.25.2",
     "@testing-library/react-native": "^13.3.3",


### PR DESCRIPTION
remove jest-native, deprecated over react native testing library

amplify/backend set to 1.20 (was already resolving to 1.20).