### PR TITLE
Fix URLs intercepting long press for message options, Chat Composer g…

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22795,24 +22795,24 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/aws-service-spec": {
-      "version": "0.1.115",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-service-spec/-/aws-service-spec-0.1.115.tgz",
-      "integrity": "sha512-NWrQNMqnocOgK1L5B43PQurxyJBS8xnPCEtHCneMXYI9l3jvARZw7/LjgXkkb0g/F4secRJMExEuHYr2qSBxwQ==",
+      "version": "0.1.143",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-service-spec/-/aws-service-spec-0.1.143.tgz",
+      "integrity": "sha512-W0FehRUeUN4juIeY7fcJlFW+VPmcru42pq6tg8axDTnS4VwvMt32w6at4H3WLcUm4NY4SMSd18Q0u5lrhyCINg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/service-spec-types": "^0.0.181",
-        "@cdklabs/tskb": "^0.0.3"
+        "@aws-cdk/service-spec-types": "^0.0.209",
+        "@cdklabs/tskb": "^0.0.4"
       }
     },
     "node_modules/@aws-cdk/aws-service-spec/node_modules/@aws-cdk/service-spec-types": {
-      "version": "0.0.181",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/service-spec-types/-/service-spec-types-0.0.181.tgz",
-      "integrity": "sha512-HULC75yEwKFyN3sQJtuWZF4WIhS5A/4ijnWaPMp5j1qbJaT714QFBvdy/B5q2cxSEtbUPvbpjMIYdqp21kx/cQ==",
+      "version": "0.0.209",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/service-spec-types/-/service-spec-types-0.0.209.tgz",
+      "integrity": "sha512-S/NTyR3CoJczjnVLEto4u4uJyNa4ZZ8/XwgND/TYTy9YIHnxvsKmA9bSz4MVDrx/hEiau/1qGRgbY9IzwXiTaw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@cdklabs/tskb": "^0.0.3"
+        "@cdklabs/tskb": "^0.0.4"
       }
     },
     "node_modules/@aws-cdk/cdk-assets-lib": {
@@ -23004,14 +23004,14 @@
       }
     },
     "node_modules/@aws-cdk/cloudformation-diff": {
-      "version": "2.184.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloudformation-diff/-/cloudformation-diff-2.184.1.tgz",
-      "integrity": "sha512-aQKe2XxI7b0jLDywr6+BQVXWZ61a8oEGjSFeklIkcytH5+tzq7dGSEh1U/d/CpfiQH7C0GMgwyuSCxiakjT7lg==",
+      "version": "2.185.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloudformation-diff/-/cloudformation-diff-2.185.0.tgz",
+      "integrity": "sha512-WIsD7p6UkAc1n+RC7ZizcwoPYyVGYDxhEzZ98ROcoWQ9AZQQjBiEV56fmRCQWmYDudNheH6DOuIN/AOihyAheg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/aws-service-spec": "^0.1.95",
-        "@aws-cdk/service-spec-types": "^0.0.161",
+        "@aws-cdk/aws-service-spec": "^0.1.130",
+        "@aws-cdk/service-spec-types": "^0.0.196",
         "chalk": "^4",
         "diff": "^7.0.0",
         "fast-deep-equal": "^3.1.3",
@@ -23102,13 +23102,13 @@
       }
     },
     "node_modules/@aws-cdk/service-spec-types": {
-      "version": "0.0.161",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/service-spec-types/-/service-spec-types-0.0.161.tgz",
-      "integrity": "sha512-GT1QaeEP3AKnwEerB3wGQ15OM5QPX8xVkjF/wq71RkX4rnqeMX4h4OSZFZUV/8gW2j2c74LHwPIJ15xSTBt54w==",
+      "version": "0.0.196",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/service-spec-types/-/service-spec-types-0.0.196.tgz",
+      "integrity": "sha512-ZLjsw8uTI89nKkJz1uBbmC0d0lJEqogTkKFYu4xDbpIZkdra7DHVqhFhDzNP9jJof3SHn9k5EOfW6yLPxe79JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@cdklabs/tskb": "^0.0.3"
+        "@cdklabs/tskb": "^0.0.4"
       }
     },
     "node_modules/@aws-cdk/toolkit-lib": {
@@ -46853,46 +46853,46 @@
       }
     },
     "node_modules/@aws-sdk/client-sts": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.972.0.tgz",
-      "integrity": "sha512-/gckLVcXO1xzAIzpXtnBAFSFfr1zBZLZtxeBSAyknSGse5J4pY9phnKzSOSJfisBjN/1M45deRgk8qA4cpJUyQ==",
+      "version": "3.975.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.975.0.tgz",
+      "integrity": "sha512-09uQiFTXZb0M2Vms2TtpPXZHAuySAEq66I7q4G2saJBNZyXFXmtTqtl3LGR+Y967RVl9UNOwvSR6hYiCHjDrYQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.972.0",
-        "@aws-sdk/credential-provider-node": "3.972.0",
-        "@aws-sdk/middleware-host-header": "3.972.0",
-        "@aws-sdk/middleware-logger": "3.972.0",
-        "@aws-sdk/middleware-recursion-detection": "3.972.0",
-        "@aws-sdk/middleware-user-agent": "3.972.0",
-        "@aws-sdk/region-config-resolver": "3.972.0",
-        "@aws-sdk/types": "3.972.0",
+        "@aws-sdk/core": "^3.973.1",
+        "@aws-sdk/credential-provider-node": "^3.972.1",
+        "@aws-sdk/middleware-host-header": "^3.972.1",
+        "@aws-sdk/middleware-logger": "^3.972.1",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.1",
+        "@aws-sdk/middleware-user-agent": "^3.972.2",
+        "@aws-sdk/region-config-resolver": "^3.972.1",
+        "@aws-sdk/types": "^3.973.0",
         "@aws-sdk/util-endpoints": "3.972.0",
-        "@aws-sdk/util-user-agent-browser": "3.972.0",
-        "@aws-sdk/util-user-agent-node": "3.972.0",
+        "@aws-sdk/util-user-agent-browser": "^3.972.1",
+        "@aws-sdk/util-user-agent-node": "^3.972.1",
         "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.20.6",
+        "@smithy/core": "^3.21.1",
         "@smithy/fetch-http-handler": "^5.3.9",
         "@smithy/hash-node": "^4.2.8",
         "@smithy/invalid-dependency": "^4.2.8",
         "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.7",
-        "@smithy/middleware-retry": "^4.4.23",
+        "@smithy/middleware-endpoint": "^4.4.11",
+        "@smithy/middleware-retry": "^4.4.27",
         "@smithy/middleware-serde": "^4.2.9",
         "@smithy/middleware-stack": "^4.2.8",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/node-http-handler": "^4.4.8",
         "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.10.8",
+        "@smithy/smithy-client": "^4.10.12",
         "@smithy/types": "^4.12.0",
         "@smithy/url-parser": "^4.2.8",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.2.0",
         "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.22",
-        "@smithy/util-defaults-mode-node": "^4.2.25",
+        "@smithy/util-defaults-mode-browser": "^4.3.26",
+        "@smithy/util-defaults-mode-node": "^4.2.29",
         "@smithy/util-endpoints": "^3.2.8",
         "@smithy/util-middleware": "^4.2.8",
         "@smithy/util-retry": "^4.2.8",
@@ -46904,45 +46904,45 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/client-sso": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.972.0.tgz",
-      "integrity": "sha512-5qw6qLiRE4SUiz0hWy878dSR13tSVhbTWhsvFT8mGHe37NRRiaobm5MA2sWD0deRAuO98djSiV+dhWXa1xIFNw==",
+      "version": "3.974.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.974.0.tgz",
+      "integrity": "sha512-ci+GiM0c4ULo4D79UMcY06LcOLcfvUfiyt8PzNY0vbt5O8BfCPYf4QomwVgkNcLLCYmroO4ge2Yy1EsLUlcD6g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.972.0",
-        "@aws-sdk/middleware-host-header": "3.972.0",
-        "@aws-sdk/middleware-logger": "3.972.0",
-        "@aws-sdk/middleware-recursion-detection": "3.972.0",
-        "@aws-sdk/middleware-user-agent": "3.972.0",
-        "@aws-sdk/region-config-resolver": "3.972.0",
-        "@aws-sdk/types": "3.972.0",
+        "@aws-sdk/core": "^3.973.0",
+        "@aws-sdk/middleware-host-header": "^3.972.1",
+        "@aws-sdk/middleware-logger": "^3.972.1",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.1",
+        "@aws-sdk/middleware-user-agent": "^3.972.1",
+        "@aws-sdk/region-config-resolver": "^3.972.1",
+        "@aws-sdk/types": "^3.973.0",
         "@aws-sdk/util-endpoints": "3.972.0",
-        "@aws-sdk/util-user-agent-browser": "3.972.0",
-        "@aws-sdk/util-user-agent-node": "3.972.0",
+        "@aws-sdk/util-user-agent-browser": "^3.972.1",
+        "@aws-sdk/util-user-agent-node": "^3.972.1",
         "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.20.6",
+        "@smithy/core": "^3.21.0",
         "@smithy/fetch-http-handler": "^5.3.9",
         "@smithy/hash-node": "^4.2.8",
         "@smithy/invalid-dependency": "^4.2.8",
         "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.7",
-        "@smithy/middleware-retry": "^4.4.23",
+        "@smithy/middleware-endpoint": "^4.4.10",
+        "@smithy/middleware-retry": "^4.4.26",
         "@smithy/middleware-serde": "^4.2.9",
         "@smithy/middleware-stack": "^4.2.8",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/node-http-handler": "^4.4.8",
         "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.10.8",
+        "@smithy/smithy-client": "^4.10.11",
         "@smithy/types": "^4.12.0",
         "@smithy/url-parser": "^4.2.8",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.2.0",
         "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.22",
-        "@smithy/util-defaults-mode-node": "^4.2.25",
+        "@smithy/util-defaults-mode-browser": "^4.3.25",
+        "@smithy/util-defaults-mode-node": "^4.2.28",
         "@smithy/util-endpoints": "^3.2.8",
         "@smithy/util-middleware": "^4.2.8",
         "@smithy/util-retry": "^4.2.8",
@@ -46954,20 +46954,20 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/core": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.972.0.tgz",
-      "integrity": "sha512-nEeUW2M9F+xdIaD98F5MBcQ4ITtykj3yKbgFZ6J0JtL3bq+Z90szQ6Yy8H/BLPYXTs3V4n9ifnBo8cprRDiE6A==",
+      "version": "3.973.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.1.tgz",
+      "integrity": "sha512-Ocubx42QsMyVs9ANSmFpRm0S+hubWljpPLjOi9UFrtcnVJjrVJTzQ51sN0e5g4e8i8QZ7uY73zosLmgYL7kZTQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.972.0",
-        "@aws-sdk/xml-builder": "3.972.0",
-        "@smithy/core": "^3.20.6",
+        "@aws-sdk/types": "^3.973.0",
+        "@aws-sdk/xml-builder": "^3.972.1",
+        "@smithy/core": "^3.21.1",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/signature-v4": "^5.3.8",
-        "@smithy/smithy-client": "^4.10.8",
+        "@smithy/smithy-client": "^4.10.12",
         "@smithy/types": "^4.12.0",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-middleware": "^4.2.8",
@@ -46979,14 +46979,14 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.0.tgz",
-      "integrity": "sha512-kKHoNv+maHlPQOAhYamhap0PObd16SAb3jwaY0KYgNTiSbeXlbGUZPLioo9oA3wU10zItJzx83ClU7d7h40luA==",
+      "version": "3.972.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.1.tgz",
+      "integrity": "sha512-/etNHqnx96phy/SjI0HRC588o4vKH5F0xfkZ13yAATV7aNrb+5gYGNE6ePWafP+FuZ3HkULSSlJFj0AxgrAqYw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.972.0",
-        "@aws-sdk/types": "3.972.0",
+        "@aws-sdk/core": "^3.973.0",
+        "@aws-sdk/types": "^3.973.0",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
@@ -46996,19 +46996,19 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.0.tgz",
-      "integrity": "sha512-xzEi81L7I5jGUbpmqEHCe7zZr54hCABdj4H+3LzktHYuovV/oqnvoDdvZpGFR0e/KAw1+PL38NbGrpG30j6qlA==",
+      "version": "3.972.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.2.tgz",
+      "integrity": "sha512-mXgdaUfe5oM+tWKyeZ7Vh/iQ94FrkMky1uuzwTOmFADiRcSk5uHy/e3boEFedXiT/PRGzgBmqvJVK4F6lUISCg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.972.0",
-        "@aws-sdk/types": "3.972.0",
+        "@aws-sdk/core": "^3.973.1",
+        "@aws-sdk/types": "^3.973.0",
         "@smithy/fetch-http-handler": "^5.3.9",
         "@smithy/node-http-handler": "^4.4.8",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.10.8",
+        "@smithy/smithy-client": "^4.10.12",
         "@smithy/types": "^4.12.0",
         "@smithy/util-stream": "^4.5.10",
         "tslib": "^2.6.2"
@@ -47018,21 +47018,21 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.0.tgz",
-      "integrity": "sha512-ruhAMceUIq2aknFd3jhWxmO0P0Efab5efjyIXOkI9i80g+zDY5VekeSxfqRKStEEJSKSCHDLQuOu0BnAn4Rzew==",
+      "version": "3.972.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.1.tgz",
+      "integrity": "sha512-OdbJA3v+XlNDsrYzNPRUwr8l7gw1r/nR8l4r96MDzSBDU8WEo8T6C06SvwaXR8SpzsjO3sq5KMP86wXWg7Rj4g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.972.0",
-        "@aws-sdk/credential-provider-env": "3.972.0",
-        "@aws-sdk/credential-provider-http": "3.972.0",
-        "@aws-sdk/credential-provider-login": "3.972.0",
-        "@aws-sdk/credential-provider-process": "3.972.0",
-        "@aws-sdk/credential-provider-sso": "3.972.0",
-        "@aws-sdk/credential-provider-web-identity": "3.972.0",
-        "@aws-sdk/nested-clients": "3.972.0",
-        "@aws-sdk/types": "3.972.0",
+        "@aws-sdk/core": "^3.973.0",
+        "@aws-sdk/credential-provider-env": "^3.972.1",
+        "@aws-sdk/credential-provider-http": "^3.972.1",
+        "@aws-sdk/credential-provider-login": "^3.972.1",
+        "@aws-sdk/credential-provider-process": "^3.972.1",
+        "@aws-sdk/credential-provider-sso": "^3.972.1",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.1",
+        "@aws-sdk/nested-clients": "3.974.0",
+        "@aws-sdk/types": "^3.973.0",
         "@smithy/credential-provider-imds": "^4.2.8",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
@@ -47044,15 +47044,15 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.0.tgz",
-      "integrity": "sha512-SsrsFJsEYAJHO4N/r2P0aK6o8si6f1lprR+Ej8J731XJqTckSGs/HFHcbxOyW/iKt+LNUvZa59/VlJmjhF4bEQ==",
+      "version": "3.972.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.1.tgz",
+      "integrity": "sha512-CccqDGL6ZrF3/EFWZefvKW7QwwRdxlHUO8NVBKNVcNq6womrPDvqB6xc9icACtE0XB0a7PLoSTkAg8bQVkTO2w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.972.0",
-        "@aws-sdk/nested-clients": "3.972.0",
-        "@aws-sdk/types": "3.972.0",
+        "@aws-sdk/core": "^3.973.0",
+        "@aws-sdk/nested-clients": "3.974.0",
+        "@aws-sdk/types": "^3.973.0",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
@@ -47064,19 +47064,19 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.0.tgz",
-      "integrity": "sha512-wwJDpEGl6+sOygic8QKu0OHVB8SiodqF1fr5jvUlSFfS6tJss/E9vBc2aFjl7zI6KpAIYfIzIgM006lRrZtWCQ==",
+      "version": "3.972.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.1.tgz",
+      "integrity": "sha512-DwXPk9GfuU/xG9tmCyXFVkCr6X3W8ZCoL5Ptb0pbltEx1/LCcg7T+PBqDlPiiinNCD6ilIoMJDWsnJ8ikzZA7Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.972.0",
-        "@aws-sdk/credential-provider-http": "3.972.0",
-        "@aws-sdk/credential-provider-ini": "3.972.0",
-        "@aws-sdk/credential-provider-process": "3.972.0",
-        "@aws-sdk/credential-provider-sso": "3.972.0",
-        "@aws-sdk/credential-provider-web-identity": "3.972.0",
-        "@aws-sdk/types": "3.972.0",
+        "@aws-sdk/credential-provider-env": "^3.972.1",
+        "@aws-sdk/credential-provider-http": "^3.972.1",
+        "@aws-sdk/credential-provider-ini": "^3.972.1",
+        "@aws-sdk/credential-provider-process": "^3.972.1",
+        "@aws-sdk/credential-provider-sso": "^3.972.1",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.1",
+        "@aws-sdk/types": "^3.973.0",
         "@smithy/credential-provider-imds": "^4.2.8",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
@@ -47088,14 +47088,14 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.0.tgz",
-      "integrity": "sha512-nmzYhamLDJ8K+v3zWck79IaKMc350xZnWsf/GeaXO6E3MewSzd3lYkTiMi7lEp3/UwDm9NHfPguoPm+mhlSWQQ==",
+      "version": "3.972.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.1.tgz",
+      "integrity": "sha512-bi47Zigu3692SJwdBvo8y1dEwE6B61stCwCFnuRWJVTfiM84B+VTSCV661CSWJmIZzmcy7J5J3kWyxL02iHj0w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.972.0",
-        "@aws-sdk/types": "3.972.0",
+        "@aws-sdk/core": "^3.973.0",
+        "@aws-sdk/types": "^3.973.0",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
         "@smithy/types": "^4.12.0",
@@ -47106,16 +47106,16 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.0.tgz",
-      "integrity": "sha512-6mYyfk1SrMZ15cH9T53yAF4YSnvq4yU1Xlgm3nqV1gZVQzmF5kr4t/F3BU3ygbvzi4uSwWxG3I3TYYS5eMlAyg==",
+      "version": "3.972.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.1.tgz",
+      "integrity": "sha512-dLZVNhM7wSgVUFsgVYgI5hb5Z/9PUkT46pk/SHrSmUqfx6YDvoV4YcPtaiRqviPpEGGiRtdQMEadyOKIRqulUQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.972.0",
-        "@aws-sdk/core": "3.972.0",
-        "@aws-sdk/token-providers": "3.972.0",
-        "@aws-sdk/types": "3.972.0",
+        "@aws-sdk/client-sso": "3.974.0",
+        "@aws-sdk/core": "^3.973.0",
+        "@aws-sdk/token-providers": "3.974.0",
+        "@aws-sdk/types": "^3.973.0",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
         "@smithy/types": "^4.12.0",
@@ -47126,15 +47126,15 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.0.tgz",
-      "integrity": "sha512-vsJXBGL8H54kz4T6do3p5elATj5d1izVGUXMluRJntm9/I0be/zUYtdd4oDTM2kSUmd4Zhyw3fMQ9lw7CVhd4A==",
+      "version": "3.972.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.1.tgz",
+      "integrity": "sha512-YMDeYgi0u687Ay0dAq/pFPKuijrlKTgsaB/UATbxCs/FzZfMiG4If5ksywHmmW7MiYUF8VVv+uou3TczvLrN4w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.972.0",
-        "@aws-sdk/nested-clients": "3.972.0",
-        "@aws-sdk/types": "3.972.0",
+        "@aws-sdk/core": "^3.973.0",
+        "@aws-sdk/nested-clients": "3.974.0",
+        "@aws-sdk/types": "^3.973.0",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
         "@smithy/types": "^4.12.0",
@@ -47145,13 +47145,13 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.0.tgz",
-      "integrity": "sha512-3eztFI6F9/eHtkIaWKN3nT+PM+eQ6p1MALDuNshFk323ixuCZzOOVT8oUqtZa30Z6dycNXJwhlIq7NhUVFfimw==",
+      "version": "3.972.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.1.tgz",
+      "integrity": "sha512-/R82lXLPmZ9JaUGSUdKtBp2k/5xQxvBT3zZWyKiBOhyulFotlfvdlrO8TnqstBimsl4lYEYySDL+W6ldFh6ALg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.972.0",
+        "@aws-sdk/types": "^3.973.0",
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
@@ -47161,13 +47161,13 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.0.tgz",
-      "integrity": "sha512-ZvdyVRwzK+ra31v1pQrgbqR/KsLD+wwJjHgko6JfoKUBIcEfAwJzQKO6HspHxdHWTVUz6MgvwskheR/TTYZl2g==",
+      "version": "3.972.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.1.tgz",
+      "integrity": "sha512-JGgFl6cHg9G2FHu4lyFIzmFN8KESBiRr84gLC3Aeni0Gt1nKm+KxWLBuha/RPcXxJygGXCcMM4AykkIwxor8RA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.972.0",
+        "@aws-sdk/types": "^3.973.0",
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
@@ -47176,13 +47176,13 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.0.tgz",
-      "integrity": "sha512-F2SmUeO+S6l1h6dydNet3BQIk173uAkcfU1HDkw/bUdRLAnh15D3HP9vCZ7oCPBNcdEICbXYDmx0BR9rRUHGlQ==",
+      "version": "3.972.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.1.tgz",
+      "integrity": "sha512-taGzNRe8vPHjnliqXIHp9kBgIemLE/xCaRTMH1NH0cncHeaPcjxtnCroAAM9aOlPuKvBe2CpZESyvM1+D8oI7Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.972.0",
+        "@aws-sdk/types": "^3.973.0",
         "@aws/lambda-invoke-store": "^0.2.2",
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/types": "^4.12.0",
@@ -47193,16 +47193,16 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.0.tgz",
-      "integrity": "sha512-kFHQm2OCBJCzGWRafgdWHGFjitUXY/OxXngymcX4l8CiyiNDZB27HDDBg2yLj3OUJc4z4fexLMmP8r9vgag19g==",
+      "version": "3.972.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.2.tgz",
+      "integrity": "sha512-d+Exq074wy0X6wvShg/kmZVtkah+28vMuqCtuY3cydg8LUZOJBtbAolCpEJizSyb8mJJZF9BjWaTANXL4OYnkg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.972.0",
-        "@aws-sdk/types": "3.972.0",
+        "@aws-sdk/core": "^3.973.1",
+        "@aws-sdk/types": "^3.973.0",
         "@aws-sdk/util-endpoints": "3.972.0",
-        "@smithy/core": "^3.20.6",
+        "@smithy/core": "^3.21.1",
         "@smithy/protocol-http": "^5.3.8",
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
@@ -47212,45 +47212,45 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.972.0.tgz",
-      "integrity": "sha512-QGlbnuGzSQJVG6bR9Qw6G0Blh6abFR4VxNa61ttMbzy9jt28xmk2iGtrYLrQPlCCPhY6enHqjTWm3n3LOb0wAw==",
+      "version": "3.974.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.974.0.tgz",
+      "integrity": "sha512-k3dwdo/vOiHMJc9gMnkPl1BA5aQfTrZbz+8fiDkWrPagqAioZgmo5oiaOaeX0grObfJQKDtcpPFR4iWf8cgl8Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.972.0",
-        "@aws-sdk/middleware-host-header": "3.972.0",
-        "@aws-sdk/middleware-logger": "3.972.0",
-        "@aws-sdk/middleware-recursion-detection": "3.972.0",
-        "@aws-sdk/middleware-user-agent": "3.972.0",
-        "@aws-sdk/region-config-resolver": "3.972.0",
-        "@aws-sdk/types": "3.972.0",
+        "@aws-sdk/core": "^3.973.0",
+        "@aws-sdk/middleware-host-header": "^3.972.1",
+        "@aws-sdk/middleware-logger": "^3.972.1",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.1",
+        "@aws-sdk/middleware-user-agent": "^3.972.1",
+        "@aws-sdk/region-config-resolver": "^3.972.1",
+        "@aws-sdk/types": "^3.973.0",
         "@aws-sdk/util-endpoints": "3.972.0",
-        "@aws-sdk/util-user-agent-browser": "3.972.0",
-        "@aws-sdk/util-user-agent-node": "3.972.0",
+        "@aws-sdk/util-user-agent-browser": "^3.972.1",
+        "@aws-sdk/util-user-agent-node": "^3.972.1",
         "@smithy/config-resolver": "^4.4.6",
-        "@smithy/core": "^3.20.6",
+        "@smithy/core": "^3.21.0",
         "@smithy/fetch-http-handler": "^5.3.9",
         "@smithy/hash-node": "^4.2.8",
         "@smithy/invalid-dependency": "^4.2.8",
         "@smithy/middleware-content-length": "^4.2.8",
-        "@smithy/middleware-endpoint": "^4.4.7",
-        "@smithy/middleware-retry": "^4.4.23",
+        "@smithy/middleware-endpoint": "^4.4.10",
+        "@smithy/middleware-retry": "^4.4.26",
         "@smithy/middleware-serde": "^4.2.9",
         "@smithy/middleware-stack": "^4.2.8",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/node-http-handler": "^4.4.8",
         "@smithy/protocol-http": "^5.3.8",
-        "@smithy/smithy-client": "^4.10.8",
+        "@smithy/smithy-client": "^4.10.11",
         "@smithy/types": "^4.12.0",
         "@smithy/url-parser": "^4.2.8",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.2.0",
         "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.22",
-        "@smithy/util-defaults-mode-node": "^4.2.25",
+        "@smithy/util-defaults-mode-browser": "^4.3.25",
+        "@smithy/util-defaults-mode-node": "^4.2.28",
         "@smithy/util-endpoints": "^3.2.8",
         "@smithy/util-middleware": "^4.2.8",
         "@smithy/util-retry": "^4.2.8",
@@ -47262,13 +47262,13 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.0.tgz",
-      "integrity": "sha512-JyOf+R/6vJW8OEVFCAyzEOn2reri/Q+L0z9zx4JQSKWvTmJ1qeFO25sOm8VIfB8URKhfGRTQF30pfYaH2zxt/A==",
+      "version": "3.972.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.1.tgz",
+      "integrity": "sha512-voIY8RORpxLAEgEkYaTFnkaIuRwVBEc+RjVZYcSSllPV+ZEKAacai6kNhJeE3D70Le+JCfvRb52tng/AVHY+jQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.972.0",
+        "@aws-sdk/types": "^3.973.0",
         "@smithy/config-resolver": "^4.4.6",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/types": "^4.12.0",
@@ -47279,15 +47279,15 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/token-providers": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.972.0.tgz",
-      "integrity": "sha512-kWlXG+y5nZhgXGEtb72Je+EvqepBPs8E3vZse//1PYLWs2speFqbGE/ywCXmzEJgHgVqSB/u/lqBvs5WlYmSqQ==",
+      "version": "3.974.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.974.0.tgz",
+      "integrity": "sha512-cBykL0LiccKIgNhGWvQRTPvsBLPZxnmJU3pYxG538jpFX8lQtrCy1L7mmIHNEdxIdIGEPgAEHF8/JQxgBToqUQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.972.0",
-        "@aws-sdk/nested-clients": "3.972.0",
-        "@aws-sdk/types": "3.972.0",
+        "@aws-sdk/core": "^3.973.0",
+        "@aws-sdk/nested-clients": "3.974.0",
+        "@aws-sdk/types": "^3.973.0",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/shared-ini-file-loader": "^4.4.3",
         "@smithy/types": "^4.12.0",
@@ -47298,9 +47298,9 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/types": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.972.0.tgz",
-      "integrity": "sha512-U7xBIbLSetONxb2bNzHyDgND3oKGoIfmknrEVnoEU4GUSs+0augUOIn9DIWGUO2ETcRFdsRUnmx9KhPT9Ojbug==",
+      "version": "3.973.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.0.tgz",
+      "integrity": "sha512-jYIdB7a7jhRTvyb378nsjyvJh1Si+zVduJ6urMNGpz8RjkmHZ+9vM2H07XaIB2Cfq0GhJRZYOfUCH8uqQhqBkQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -47328,28 +47328,42 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-browser": {
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-endpoints/node_modules/@aws-sdk/types": {
       "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.0.tgz",
-      "integrity": "sha512-eOLdkQyoRbDgioTS3Orr7iVsVEutJyMZxvyZ6WAF95IrF0kfWx5Rd/KXnfbnG/VKa2CvjZiitWfouLzfVEyvJA==",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.972.0.tgz",
+      "integrity": "sha512-U7xBIbLSetONxb2bNzHyDgND3oKGoIfmknrEVnoEU4GUSs+0augUOIn9DIWGUO2ETcRFdsRUnmx9KhPT9Ojbug==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.972.0",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.1.tgz",
+      "integrity": "sha512-IgF55NFmJX8d9Wql9M0nEpk2eYbuD8G4781FN4/fFgwTXBn86DvlZJuRWDCMcMqZymnBVX7HW9r+3r9ylqfW0w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.0",
         "@smithy/types": "^4.12.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.972.0.tgz",
-      "integrity": "sha512-GOy+AiSrE9kGiojiwlZvVVSXwylu4+fmP0MJfvras/MwP09RB/YtQuOVR1E0fKQc6OMwaTNBjgAbOEhxuWFbAw==",
+      "version": "3.972.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.972.1.tgz",
+      "integrity": "sha512-oIs4JFcADzoZ0c915R83XvK2HltWupxNsXUIuZse2rgk7b97zTpkxaqXiH0h9ylh31qtgo/t8hp4tIqcsMrEbQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.972.0",
-        "@aws-sdk/types": "3.972.0",
+        "@aws-sdk/middleware-user-agent": "^3.972.1",
+        "@aws-sdk/types": "^3.973.0",
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
@@ -47367,9 +47381,9 @@
       }
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.0.tgz",
-      "integrity": "sha512-POaGMcXnozzqBUyJM3HLUZ9GR6OKJWPGJEmhtTnxZXt8B6JcJ/6K3xRJ5H/j8oovVLz8Wg6vFxAHv8lvuASxMg==",
+      "version": "3.972.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.1.tgz",
+      "integrity": "sha512-6zZGlPOqn7Xb+25MAXGb1JhgvaC5HjZj6GzszuVrnEgbhvzBRFGKYemuHBV4bho+dtqeYKPgaZUv7/e80hIGNg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -47391,393 +47405,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/abort-controller": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.8.tgz",
-      "integrity": "sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/config-resolver": {
-      "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.6.tgz",
-      "integrity": "sha512-qJpzYC64kaj3S0fueiu3kXm8xPrR3PcXDPEgnaNMRn0EjNSZFoFjvbUp0YUDsRhN1CB90EnHJtbxWKevnH99UQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-config-provider": "^4.2.0",
-        "@smithy/util-endpoints": "^3.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/core": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.21.0.tgz",
-      "integrity": "sha512-bg2TfzgsERyETAxc/Ims/eJX8eAnIeTi4r4LHpMpfF/2NyO6RsWis0rjKcCPaGksljmOb23BZRiCeT/3NvwkXw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-stream": "^4.5.10",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/uuid": "^1.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.8.tgz",
-      "integrity": "sha512-FNT0xHS1c/CPN8upqbMFP83+ul5YgdisfCfkZ86Jh2NSmnqw/AJ6x5pEogVCTVvSm7j9MopRU89bmDelxuDMYw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.9",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.9.tgz",
-      "integrity": "sha512-I4UhmcTYXBrct03rwzQX1Y/iqQlzVQaPxWjCjula++5EmWq9YGBrx6bbGqluGc1f0XEfhSkiY4jhLgbsJUMKRA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/querystring-builder": "^4.2.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/hash-node": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.8.tgz",
-      "integrity": "sha512-7ZIlPbmaDGxVoxErDZnuFG18WekhbA/g2/i97wGj+wUBeS6pcUeAym8u4BXh/75RXWhgIJhyC11hBzig6MljwA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.8.tgz",
-      "integrity": "sha512-N9iozRybwAQ2dn9Fot9kI6/w9vos2oTXLhtK7ovGqwZjlOcxu6XhPlpLpC+INsxktqHinn5gS2DXDjDF2kG5sQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.8.tgz",
-      "integrity": "sha512-RO0jeoaYAB1qBRhfVyq0pMgBoUK34YEJxVxyjOWYZiOKOq2yMZ4MnVXMZCUDenpozHue207+9P5ilTV1zeda0A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.10.tgz",
-      "integrity": "sha512-kwWpNltpxrvPabnjEFvwSmA+66l6s2ReCvgVSzW/z92LU4T28fTdgZ18IdYRYOrisu2NMQ0jUndRScbO65A/zg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.21.0",
-        "@smithy/middleware-serde": "^4.2.9",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
-        "@smithy/url-parser": "^4.2.8",
-        "@smithy/util-middleware": "^4.2.8",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-retry": {
-      "version": "4.4.26",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.26.tgz",
-      "integrity": "sha512-ozZMoTAr+B2aVYfLYfkssFvc8ZV3p/vLpVQ7/k277xxUOA9ykSPe5obL2j6yHfbdrM/SZV7qj0uk/hSqavHrLw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/service-error-classification": "^4.2.8",
-        "@smithy/smithy-client": "^4.10.11",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-retry": "^4.2.8",
-        "@smithy/uuid": "^1.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-serde": {
-      "version": "4.2.9",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.9.tgz",
-      "integrity": "sha512-eMNiej0u/snzDvlqRGSN3Vl0ESn3838+nKyVfF2FKNXFbi4SERYT6PR392D39iczngbqqGG0Jl1DlCnp7tBbXQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/middleware-stack": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.8.tgz",
-      "integrity": "sha512-w6LCfOviTYQjBctOKSwy6A8FIkQy7ICvglrZFl6Bw4FmcQ1Z420fUtIhxaUZZshRe0VCq4kvDiPiXrPZAe8oRA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/node-config-provider": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.8.tgz",
-      "integrity": "sha512-aFP1ai4lrbVlWjfpAfRSL8KFcnJQYfTl5QxLJXY32vghJrDuFyPZ6LtUL+JEGYiFRG1PfPLHLoxj107ulncLIg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/shared-ini-file-loader": "^4.4.3",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/node-http-handler": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.8.tgz",
-      "integrity": "sha512-q9u+MSbJVIJ1QmJ4+1u+cERXkrhuILCBDsJUBAW1MPE6sFonbCNaegFuwW9ll8kh5UdyY3jOkoOGlc7BesoLpg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/abort-controller": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/querystring-builder": "^4.2.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/property-provider": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.8.tgz",
-      "integrity": "sha512-EtCTbyIveCKeOXDSWSdze3k612yCPq1YbXsbqX3UHhkOSW8zKsM9NOJG5gTIya0vbY2DIaieG8pKo1rITHYL0w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/protocol-http": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.8.tgz",
-      "integrity": "sha512-QNINVDhxpZ5QnP3aviNHQFlRogQZDfYlCkQT+7tJnErPQbDhysondEjhikuANxgMsZrkGeiAxXy4jguEGsDrWQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/querystring-builder": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.8.tgz",
-      "integrity": "sha512-Xr83r31+DrE8CP3MqPgMJl+pQlLLmOfiEUnoyAlGzzJIrEsbKsPy1hqH0qySaQm4oWrCBlUqRt+idEgunKB+iw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-uri-escape": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/querystring-parser": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.8.tgz",
-      "integrity": "sha512-vUurovluVy50CUlazOiXkPq40KGvGWSdmusa3130MwrR1UNnNgKAlj58wlOe61XSHRpUfIIh6cE0zZ8mzKaDPA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/service-error-classification": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.8.tgz",
-      "integrity": "sha512-mZ5xddodpJhEt3RkCjbmUQuXUOaPNTkbMGR0bcS8FE0bJDLMZlhmpgrvPNCYglVw5rsYTpSnv19womw9WWXKQQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.3.tgz",
-      "integrity": "sha512-DfQjxXQnzC5UbCUPeC3Ie8u+rIWZTvuDPAGU/BxzrOGhRvgUanaP68kDZA+jaT3ZI+djOf+4dERGlm9mWfFDrg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/signature-v4": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.8.tgz",
-      "integrity": "sha512-6A4vdGj7qKNRF16UIcO8HhHjKW27thsxYci+5r/uVRkdcBEkOEiY8OMPuydLX4QHSrJqGHPJzPRwwVTqbLZJhg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.8",
-        "@smithy/util-uri-escape": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/smithy-client": {
-      "version": "4.10.11",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.10.11.tgz",
-      "integrity": "sha512-6o804SCyHGMXAb5mFJ+iTy9kVKv7F91a9szN0J+9X6p8A0NrdpUxdaC57aye2ipQkP2C4IAqETEpGZ0Zj77Haw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.21.0",
-        "@smithy/middleware-endpoint": "^4.4.10",
-        "@smithy/middleware-stack": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-stream": "^4.5.10",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/types": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.12.0.tgz",
-      "integrity": "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/url-parser": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.8.tgz",
-      "integrity": "sha512-NQho9U68TGMEU639YkXnVMV3GEFFULmmaWdlu1E9qzyIePOHsoSnagTGSDv1Zi8DCNN6btxOSdgmy5E/hsZwhA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/querystring-parser": "^4.2.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-base64": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
@@ -47787,118 +47414,6 @@
       "dependencies": {
         "@smithy/util-buffer-from": "^4.2.0",
         "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.25",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.25.tgz",
-      "integrity": "sha512-8ugoNMtss2dJHsXnqsibGPqoaafvWJPACmYKxJ4E6QWaDrixsAemmiMMAVbvwYadjR0H9G2+AlzsInSzRi8PSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/smithy-client": "^4.10.11",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.28",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.28.tgz",
-      "integrity": "sha512-mjUdcP8h3E0K/XvNMi9oBXRV3DMCzeRiYIieZ1LQ7jq5tu6GH/GTWym7a1xIIE0pKSoLcpGsaImuQhGPSIJzAA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/config-resolver": "^4.4.6",
-        "@smithy/credential-provider-imds": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/property-provider": "^4.2.8",
-        "@smithy/smithy-client": "^4.10.11",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-endpoints": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.8.tgz",
-      "integrity": "sha512-8JaVTn3pBDkhZgHQ8R0epwWt+BqPSLCjdjXXusK1onwJlRuN69fbvSK66aIKKO7SwVFM6x2J2ox5X8pOaWcUEw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/node-config-provider": "^4.3.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-middleware": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.8.tgz",
-      "integrity": "sha512-PMqfeJxLcNPMDgvPbbLl/2Vpin+luxqTGPpW3NAQVLbRrFRzTa4rNAASYeIGjRV9Ytuhzny39SpyU04EQreF+A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-retry": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.8.tgz",
-      "integrity": "sha512-CfJqwvoRY0kTGe5AkQokpURNCT1u/MkRzMTASWMPPo2hNSnKtF1D45dQl3DE2LKLr4m+PW9mCeBMJr5mCAVThg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/service-error-classification": "^4.2.8",
-        "@smithy/types": "^4.12.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-stream": {
-      "version": "4.5.10",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.10.tgz",
-      "integrity": "sha512-jbqemy51UFSZSp2y0ZmRfckmrzuKww95zT9BYMmuJ8v3altGcqjwoV1tzpOwuHaKrwQrCjIzOib499ymr2f98g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.9",
-        "@smithy/node-http-handler": "^4.4.8",
-        "@smithy/types": "^4.12.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -52288,9 +51803,9 @@
       "license": "MIT"
     },
     "node_modules/@cdklabs/tskb": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@cdklabs/tskb/-/tskb-0.0.3.tgz",
-      "integrity": "sha512-JR+MuD4awAXvutu7HArephXfZm09GPTaSAQUqNcJB5+ZENRm4kV+L6vJL6Tn1xHjCcHksO+HAqj3gYtm5K94vA==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@cdklabs/tskb/-/tskb-0.0.4.tgz",
+      "integrity": "sha512-NFx1X0l7p5DyHtLLEyNeh1hPN4UN9hTkZkzFs/Mp+kFk7dpdINGmGVpCfRDjJ2DrcNSNENUmT+w8g73TvmBbTw==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -56378,12 +55893,12 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.7.tgz",
-      "integrity": "sha512-rzMY6CaKx2qxrbYbqjXWS0plqEy7LOdKHS0bg4ixJ6aoGDPNUcLWk/FRNuCILh7GKLG9TFUXYYeQQldMBBwuyw==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.8.tgz",
+      "integrity": "sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.11.0",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -56433,16 +55948,16 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.5.tgz",
-      "integrity": "sha512-HAGoUAFYsUkoSckuKbCPayECeMim8pOu+yLy1zOxt1sifzEbrsRpYa+mKcMdiHKMeiqOibyPG0sFJnmaV/OGEg==",
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.6.tgz",
+      "integrity": "sha512-qJpzYC64kaj3S0fueiu3kXm8xPrR3PcXDPEgnaNMRn0EjNSZFoFjvbUp0YUDsRhN1CB90EnHJtbxWKevnH99UQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/types": "^4.11.0",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/types": "^4.12.0",
         "@smithy/util-config-provider": "^4.2.0",
-        "@smithy/util-endpoints": "^3.2.7",
-        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-endpoints": "^3.2.8",
+        "@smithy/util-middleware": "^4.2.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -56450,18 +55965,18 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.20.2",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.20.2.tgz",
-      "integrity": "sha512-nc99TseyTwL1bg+T21cyEA5oItNy1XN4aUeyOlXJnvyRW5VSK1oRKRoSM/Iq0KFPuqZMxjBemSZHZCOZbSyBMw==",
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.21.1.tgz",
+      "integrity": "sha512-NUH8R4O6FkN8HKMojzbGg/5pNjsfTjlMmeFclyPfPaXXUrbr5TzhWgbf7t92wfrpCHRgpjyz7ffASIS3wX28aA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.2.8",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
+        "@smithy/middleware-serde": "^4.2.9",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.7",
-        "@smithy/util-stream": "^4.5.8",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-stream": "^4.5.10",
         "@smithy/util-utf8": "^4.2.0",
         "@smithy/uuid": "^1.1.0",
         "tslib": "^2.6.2"
@@ -56485,15 +56000,15 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.7.tgz",
-      "integrity": "sha512-CmduWdCiILCRNbQWFR0OcZlUPVtyE49Sr8yYL0rZQ4D/wKxiNzBNS/YHemvnbkIWj623fplgkexUd/c9CAKdoA==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.8.tgz",
+      "integrity": "sha512-FNT0xHS1c/CPN8upqbMFP83+ul5YgdisfCfkZ86Jh2NSmnqw/AJ6x5pEogVCTVvSm7j9MopRU89bmDelxuDMYw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/url-parser": "^4.2.7",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -56571,14 +56086,14 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.8.tgz",
-      "integrity": "sha512-h/Fi+o7mti4n8wx1SR6UHWLaakwHRx29sizvp8OOm7iqwKGFneT06GCSFhml6Bha5BT6ot5pj3CYZnCHhGC2Rg==",
+      "version": "5.3.9",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.9.tgz",
+      "integrity": "sha512-I4UhmcTYXBrct03rwzQX1Y/iqQlzVQaPxWjCjula++5EmWq9YGBrx6bbGqluGc1f0XEfhSkiY4jhLgbsJUMKRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/querystring-builder": "^4.2.7",
-        "@smithy/types": "^4.11.0",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/querystring-builder": "^4.2.8",
+        "@smithy/types": "^4.12.0",
         "@smithy/util-base64": "^4.3.0",
         "tslib": "^2.6.2"
       },
@@ -56587,12 +56102,12 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler/node_modules/@smithy/querystring-builder": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.7.tgz",
-      "integrity": "sha512-eKONSywHZxK4tBxe2lXEysh8wbBdvDWiA+RIuaxZSgCMmA0zMgoDpGLJhnyj+c0leOQprVnXOmcB4m+W9Rw7sg==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.8.tgz",
+      "integrity": "sha512-Xr83r31+DrE8CP3MqPgMJl+pQlLLmOfiEUnoyAlGzzJIrEsbKsPy1hqH0qySaQm4oWrCBlUqRt+idEgunKB+iw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.11.0",
+        "@smithy/types": "^4.12.0",
         "@smithy/util-uri-escape": "^4.2.0",
         "tslib": "^2.6.2"
       },
@@ -56643,12 +56158,12 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.7.tgz",
-      "integrity": "sha512-PU/JWLTBCV1c8FtB8tEFnY4eV1tSfBc7bDBADHfn1K+uRbPgSJ9jnJp0hyjiFN2PMdPzxsf1Fdu0eo9fJ760Xw==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.8.tgz",
+      "integrity": "sha512-7ZIlPbmaDGxVoxErDZnuFG18WekhbA/g2/i97wGj+wUBeS6pcUeAym8u4BXh/75RXWhgIJhyC11hBzig6MljwA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.11.0",
+        "@smithy/types": "^4.12.0",
         "@smithy/util-buffer-from": "^4.2.0",
         "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
@@ -56673,12 +56188,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.7.tgz",
-      "integrity": "sha512-ncvgCr9a15nPlkhIUx3CU4d7E7WEuVJOV7fS7nnK2hLtPK9tYRBkMHQbhXU1VvvKeBm/O0x26OEoBq+ngFpOEQ==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.8.tgz",
+      "integrity": "sha512-N9iozRybwAQ2dn9Fot9kI6/w9vos2oTXLhtK7ovGqwZjlOcxu6XhPlpLpC+INsxktqHinn5gS2DXDjDF2kG5sQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.11.0",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -56713,13 +56228,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.7.tgz",
-      "integrity": "sha512-GszfBfCcvt7kIbJ41LuNa5f0wvQCHhnGx/aDaZJCCT05Ld6x6U2s0xsc/0mBFONBZjQJp2U/0uSJ178OXOwbhg==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.8.tgz",
+      "integrity": "sha512-RO0jeoaYAB1qBRhfVyq0pMgBoUK34YEJxVxyjOWYZiOKOq2yMZ4MnVXMZCUDenpozHue207+9P5ilTV1zeda0A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -56727,18 +56242,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.3.tgz",
-      "integrity": "sha512-Zb8R35hjBhp1oFhiaAZ9QhClpPHdEDmNDC2UrrB2fqV0oNDUUPH12ovZHB5xi/Rd+pg/BJHOR1q+SfsieSKPQg==",
+      "version": "4.4.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.11.tgz",
+      "integrity": "sha512-/WqsrycweGGfb9sSzME4CrsuayjJF6BueBmkKlcbeU5q18OhxRrvvKlmfw3tpDsK5ilx2XUJvoukwxHB0nHs/Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.20.2",
-        "@smithy/middleware-serde": "^4.2.8",
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/shared-ini-file-loader": "^4.4.2",
-        "@smithy/types": "^4.11.0",
-        "@smithy/url-parser": "^4.2.7",
-        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/core": "^3.21.1",
+        "@smithy/middleware-serde": "^4.2.9",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-middleware": "^4.2.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -56746,18 +56261,18 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.19",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.19.tgz",
-      "integrity": "sha512-QtisFIjIw2tjMm/ESatjWFVIQb5Xd093z8xhxq/SijLg7Mgo2C2wod47Ib/AHpBLFhwYXPzd7Hp2+JVXfeZyMQ==",
+      "version": "4.4.27",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.27.tgz",
+      "integrity": "sha512-xFUYCGRVsfgiN5EjsJJSzih9+yjStgMTCLANPlf0LVQkPDYCe0hz97qbdTZosFOiYlGBlHYityGRxrQ/hxhfVQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/service-error-classification": "^4.2.7",
-        "@smithy/smithy-client": "^4.10.4",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-middleware": "^4.2.7",
-        "@smithy/util-retry": "^4.2.7",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/service-error-classification": "^4.2.8",
+        "@smithy/smithy-client": "^4.10.12",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-retry": "^4.2.8",
         "@smithy/uuid": "^1.1.0",
         "tslib": "^2.6.2"
       },
@@ -56766,13 +56281,13 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.8.tgz",
-      "integrity": "sha512-8rDGYen5m5+NV9eHv9ry0sqm2gI6W7mc1VSFMtn6Igo25S507/HaOX9LTHAS2/J32VXD0xSzrY0H5FJtOMS4/w==",
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.9.tgz",
+      "integrity": "sha512-eMNiej0u/snzDvlqRGSN3Vl0ESn3838+nKyVfF2FKNXFbi4SERYT6PR392D39iczngbqqGG0Jl1DlCnp7tBbXQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -56780,12 +56295,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.7.tgz",
-      "integrity": "sha512-bsOT0rJ+HHlZd9crHoS37mt8qRRN/h9jRve1SXUhVbkRzu0QaNYZp1i1jha4n098tsvROjcwfLlfvcFuJSXEsw==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.8.tgz",
+      "integrity": "sha512-w6LCfOviTYQjBctOKSwy6A8FIkQy7ICvglrZFl6Bw4FmcQ1Z420fUtIhxaUZZshRe0VCq4kvDiPiXrPZAe8oRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.11.0",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -56793,14 +56308,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.7.tgz",
-      "integrity": "sha512-7r58wq8sdOcrwWe+klL9y3bc4GW1gnlfnFOuL7CXa7UzfhzhxKuzNdtqgzmTV+53lEp9NXh5hY/S4UgjLOzPfw==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.8.tgz",
+      "integrity": "sha512-aFP1ai4lrbVlWjfpAfRSL8KFcnJQYfTl5QxLJXY32vghJrDuFyPZ6LtUL+JEGYiFRG1PfPLHLoxj107ulncLIg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/shared-ini-file-loader": "^4.4.2",
-        "@smithy/types": "^4.11.0",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -56808,15 +56323,15 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.4.7",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.7.tgz",
-      "integrity": "sha512-NELpdmBOO6EpZtWgQiHjoShs1kmweaiNuETUpuup+cmm/xJYjT4eUjfhrXRP4jCOaAsS3c3yPsP3B+K+/fyPCQ==",
+      "version": "4.4.8",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.8.tgz",
+      "integrity": "sha512-q9u+MSbJVIJ1QmJ4+1u+cERXkrhuILCBDsJUBAW1MPE6sFonbCNaegFuwW9ll8kh5UdyY3jOkoOGlc7BesoLpg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/querystring-builder": "^4.2.7",
-        "@smithy/types": "^4.11.0",
+        "@smithy/abort-controller": "^4.2.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/querystring-builder": "^4.2.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -56824,12 +56339,12 @@
       }
     },
     "node_modules/@smithy/node-http-handler/node_modules/@smithy/querystring-builder": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.7.tgz",
-      "integrity": "sha512-eKONSywHZxK4tBxe2lXEysh8wbBdvDWiA+RIuaxZSgCMmA0zMgoDpGLJhnyj+c0leOQprVnXOmcB4m+W9Rw7sg==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.8.tgz",
+      "integrity": "sha512-Xr83r31+DrE8CP3MqPgMJl+pQlLLmOfiEUnoyAlGzzJIrEsbKsPy1hqH0qySaQm4oWrCBlUqRt+idEgunKB+iw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.11.0",
+        "@smithy/types": "^4.12.0",
         "@smithy/util-uri-escape": "^4.2.0",
         "tslib": "^2.6.2"
       },
@@ -56850,12 +56365,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.7.tgz",
-      "integrity": "sha512-jmNYKe9MGGPoSl/D7JDDs1C8b3dC8f/w78LbaVfoTtWy4xAd5dfjaFG9c9PWPihY4ggMQNQSMtzU77CNgAJwmA==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.8.tgz",
+      "integrity": "sha512-EtCTbyIveCKeOXDSWSdze3k612yCPq1YbXsbqX3UHhkOSW8zKsM9NOJG5gTIya0vbY2DIaieG8pKo1rITHYL0w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.11.0",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -56863,12 +56378,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.7.tgz",
-      "integrity": "sha512-1r07pb994I20dD/c2seaZhoCuNYm0rWrvBxhCQ70brNh11M5Ml2ew6qJVo0lclB3jMIXirD4s2XRXRe7QEi0xA==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.8.tgz",
+      "integrity": "sha512-QNINVDhxpZ5QnP3aviNHQFlRogQZDfYlCkQT+7tJnErPQbDhysondEjhikuANxgMsZrkGeiAxXy4jguEGsDrWQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.11.0",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -56904,12 +56419,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.7.tgz",
-      "integrity": "sha512-3X5ZvzUHmlSTHAXFlswrS6EGt8fMSIxX/c3Rm1Pni3+wYWB6cjGocmRIoqcQF9nU5OgGmL0u7l9m44tSUpfj9w==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.8.tgz",
+      "integrity": "sha512-vUurovluVy50CUlazOiXkPq40KGvGWSdmusa3130MwrR1UNnNgKAlj58wlOe61XSHRpUfIIh6cE0zZ8mzKaDPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.11.0",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -56917,24 +56432,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.7.tgz",
-      "integrity": "sha512-YB7oCbukqEb2Dlh3340/8g8vNGbs/QsNNRms+gv3N2AtZz9/1vSBx6/6tpwQpZMEJFs7Uq8h4mmOn48ZZ72MkA==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.8.tgz",
+      "integrity": "sha512-mZ5xddodpJhEt3RkCjbmUQuXUOaPNTkbMGR0bcS8FE0bJDLMZlhmpgrvPNCYglVw5rsYTpSnv19womw9WWXKQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.11.0"
+        "@smithy/types": "^4.12.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.2.tgz",
-      "integrity": "sha512-M7iUUff/KwfNunmrgtqBfvZSzh3bmFgv/j/t1Y1dQ+8dNo34br1cqVEqy6v0mYEgi0DkGO7Xig0AnuOaEGVlcg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.3.tgz",
+      "integrity": "sha512-DfQjxXQnzC5UbCUPeC3Ie8u+rIWZTvuDPAGU/BxzrOGhRvgUanaP68kDZA+jaT3ZI+djOf+4dERGlm9mWfFDrg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.11.0",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -56942,16 +56457,16 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.7.tgz",
-      "integrity": "sha512-9oNUlqBlFZFOSdxgImA6X5GFuzE7V2H7VG/7E70cdLhidFbdtvxxt81EHgykGK5vq5D3FafH//X+Oy31j3CKOg==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.8.tgz",
+      "integrity": "sha512-6A4vdGj7qKNRF16UIcO8HhHjKW27thsxYci+5r/uVRkdcBEkOEiY8OMPuydLX4QHSrJqGHPJzPRwwVTqbLZJhg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.0",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
         "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-middleware": "^4.2.8",
         "@smithy/util-uri-escape": "^4.2.0",
         "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
@@ -56973,17 +56488,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.10.4",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.10.4.tgz",
-      "integrity": "sha512-rHig+BWjhjlHlah67ryaW9DECYixiJo5pQCTEwsJyarRBAwHMMC3iYz5MXXAHXe64ZAMn1NhTUSTFIu1T6n6jg==",
+      "version": "4.10.12",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.10.12.tgz",
+      "integrity": "sha512-VKO/HKoQ5OrSHW6AJUmEnUKeXI1/5LfCwO9cwyao7CmLvGnZeM1i36Lyful3LK1XU7HwTVieTqO1y2C/6t3qtA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.20.2",
-        "@smithy/middleware-endpoint": "^4.4.3",
-        "@smithy/middleware-stack": "^4.2.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/types": "^4.11.0",
-        "@smithy/util-stream": "^4.5.8",
+        "@smithy/core": "^3.21.1",
+        "@smithy/middleware-endpoint": "^4.4.11",
+        "@smithy/middleware-stack": "^4.2.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-stream": "^4.5.10",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -56991,9 +56506,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.11.0.tgz",
-      "integrity": "sha512-mlrmL0DRDVe3mNrjTcVcZEgkFmufITfUAPBEA+AHYiIeYyJebso/He1qLbP3PssRe22KUzLRpQSdBPbXdgZ2VA==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.12.0.tgz",
+      "integrity": "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -57003,13 +56518,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.7.tgz",
-      "integrity": "sha512-/RLtVsRV4uY3qPWhBDsjwahAtt3x2IsMGnP5W1b2VZIe+qgCqkLxI1UOHDZp1Q1QSOrdOR32MF3Ph2JfWT1VHg==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.8.tgz",
+      "integrity": "sha512-NQho9U68TGMEU639YkXnVMV3GEFFULmmaWdlu1E9qzyIePOHsoSnagTGSDv1Zi8DCNN6btxOSdgmy5E/hsZwhA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.2.7",
-        "@smithy/types": "^4.11.0",
+        "@smithy/querystring-parser": "^4.2.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -57118,14 +56633,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.18",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.18.tgz",
-      "integrity": "sha512-Ao1oLH37YmLyHnKdteMp6l4KMCGBeZEAN68YYe00KAaKFijFELDbRQRm3CNplz7bez1HifuBV0l5uR6eVJLhIg==",
+      "version": "4.3.26",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.26.tgz",
+      "integrity": "sha512-vva0dzYUTgn7DdE0uaha10uEdAgmdLnNFowKFjpMm6p2R0XDk5FHPX3CBJLzWQkQXuEprsb0hGz9YwbicNWhjw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/smithy-client": "^4.10.4",
-        "@smithy/types": "^4.11.0",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/smithy-client": "^4.10.12",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -57133,17 +56648,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.21",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.21.tgz",
-      "integrity": "sha512-e21ASJDirE96kKXZLcYcnn4Zt0WGOvMYc1P8EK0gQeQ3I8PbJWqBKx9AUr/YeFpDkpYwEu1RsPe4UXk2+QL7IA==",
+      "version": "4.2.29",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.29.tgz",
+      "integrity": "sha512-c6D7IUBsZt/aNnTBHMTf+OVh+h/JcxUUgfTcIJaWRe6zhOum1X+pNKSZtZ+7fbOn5I99XVFtmrnXKv8yHHErTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.4.5",
-        "@smithy/credential-provider-imds": "^4.2.7",
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/smithy-client": "^4.10.4",
-        "@smithy/types": "^4.11.0",
+        "@smithy/config-resolver": "^4.4.6",
+        "@smithy/credential-provider-imds": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/smithy-client": "^4.10.12",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -57151,13 +56666,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.7.tgz",
-      "integrity": "sha512-s4ILhyAvVqhMDYREeTS68R43B1V5aenV5q/V1QpRQJkCXib5BPRo4s7uNdzGtIKxaPHCfU/8YkvPAEvTpxgspg==",
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.8.tgz",
+      "integrity": "sha512-8JaVTn3pBDkhZgHQ8R0epwWt+BqPSLCjdjXXusK1onwJlRuN69fbvSK66aIKKO7SwVFM6x2J2ox5X8pOaWcUEw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/types": "^4.11.0",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -57177,12 +56692,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.7.tgz",
-      "integrity": "sha512-i1IkpbOae6NvIKsEeLLM9/2q4X+M90KV3oCFgWQI4q0Qz+yUZvsr+gZPdAEAtFhWQhAHpTsJO8DRJPuwVyln+w==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.8.tgz",
+      "integrity": "sha512-PMqfeJxLcNPMDgvPbbLl/2Vpin+luxqTGPpW3NAQVLbRrFRzTa4rNAASYeIGjRV9Ytuhzny39SpyU04EQreF+A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.11.0",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -57190,13 +56705,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.7.tgz",
-      "integrity": "sha512-SvDdsQyF5CIASa4EYVT02LukPHVzAgUA4kMAuZ97QJc2BpAqZfA4PINB8/KOoCXEw9tsuv/jQjMeaHFvxdLNGg==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.8.tgz",
+      "integrity": "sha512-CfJqwvoRY0kTGe5AkQokpURNCT1u/MkRzMTASWMPPo2hNSnKtF1D45dQl3DE2LKLr4m+PW9mCeBMJr5mCAVThg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.7",
-        "@smithy/types": "^4.11.0",
+        "@smithy/service-error-classification": "^4.2.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -57204,14 +56719,14 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.8.tgz",
-      "integrity": "sha512-ZnnBhTapjM0YPGUSmOs0Mcg/Gg87k503qG4zU2v/+Js2Gu+daKOJMeqcQns8ajepY8tgzzfYxl6kQyZKml6O2w==",
+      "version": "4.5.10",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.10.tgz",
+      "integrity": "sha512-jbqemy51UFSZSp2y0ZmRfckmrzuKww95zT9BYMmuJ8v3altGcqjwoV1tzpOwuHaKrwQrCjIzOib499ymr2f98g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.8",
-        "@smithy/node-http-handler": "^4.4.7",
-        "@smithy/types": "^4.11.0",
+        "@smithy/fetch-http-handler": "^5.3.9",
+        "@smithy/node-http-handler": "^4.4.8",
+        "@smithy/types": "^4.12.0",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-buffer-from": "^4.2.0",
         "@smithy/util-hex-encoding": "^4.2.0",

--- a/frontend/src/components/RichText.tsx
+++ b/frontend/src/components/RichText.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { StyleProp, TextStyle } from 'react-native';
+import type { GestureResponderEvent, StyleProp, TextStyle } from 'react-native';
 import { Linking, Platform, Text } from 'react-native';
 
 import { useUiPromptOptional } from '../providers/UiPromptProvider';
@@ -243,6 +243,7 @@ export function RichText({
   mentionStyle,
   linkStyle,
   onOpenUrl,
+  onLongPressLink,
   numberOfLines,
   ellipsizeMode,
 }: {
@@ -254,6 +255,7 @@ export function RichText({
   mentionStyle?: StyleProp<TextStyle>;
   linkStyle?: StyleProp<TextStyle>;
   onOpenUrl?: (url: string) => void | Promise<void>;
+  onLongPressLink?: (e: GestureResponderEvent, url: string) => void;
   numberOfLines?: number;
   ellipsizeMode?: 'head' | 'middle' | 'tail' | 'clip';
 }): React.JSX.Element {
@@ -331,6 +333,9 @@ export function RichText({
                 if (typeof onOpenUrl === 'function')
                   void Promise.resolve(onOpenUrl(seg.url)).catch(() => {});
                 else void confirmAndOpenUrl(seg.url);
+              }}
+              onLongPress={(e) => {
+                if (typeof onLongPressLink === 'function') onLongPressLink(e, seg.url);
               }}
               accessibilityRole="link"
               accessibilityLabel={`Open link ${seg.url}`}

--- a/frontend/src/features/chat/components/ChatComposer.tsx
+++ b/frontend/src/features/chat/components/ChatComposer.tsx
@@ -8,10 +8,10 @@ import { AnimatedDots } from '../../../components/AnimatedDots';
 import type { ChatScreenStyles } from '../../../screens/ChatScreen.styles';
 import { APP_COLORS, PALETTE } from '../../../theme/colors';
 import type { MediaItem } from '../../../types/media';
+import { fileBrandColorForMedia, fileIconNameForMedia } from '../../../utils/mediaKinds';
 import type { PendingMediaItem } from '../attachments';
 import { normalizeChatMediaList, parseChatEnvelope } from '../parsers';
 import type { ChatMessage } from '../types';
-import { fileBrandColorForMedia, fileIconNameForMedia } from '../../../utils/mediaKinds';
 import { VoiceClipMicButton } from './VoiceClipMicButton';
 
 type ReplyTarget = null | {
@@ -484,7 +484,8 @@ export function ChatComposer(props: {
             scrollEnabled={inputHeight >= MAX_INPUT_HEIGHT}
             onContentSizeChange={(e) => {
               const hRaw = e?.nativeEvent?.contentSize?.height;
-              const h = typeof hRaw === 'number' && Number.isFinite(hRaw) ? hRaw : Number(hRaw) || 0;
+              const h =
+                typeof hRaw === 'number' && Number.isFinite(hRaw) ? hRaw : Number(hRaw) || 0;
               if (!h) return;
               const next = Math.max(MIN_INPUT_HEIGHT, Math.min(MAX_INPUT_HEIGHT, Math.ceil(h)));
               setInputHeight((prev) => (prev === next ? prev : next));

--- a/frontend/src/features/chat/components/ChatComposer.tsx
+++ b/frontend/src/features/chat/components/ChatComposer.tsx
@@ -38,6 +38,7 @@ function formatMmSs(ms: number | null | undefined): string {
 export function ChatComposer(props: {
   styles: ChatScreenStyles;
   isDark: boolean;
+  myUserId: string | null;
   isDm: boolean;
   isGroup: boolean;
   isEncryptedChat: boolean;
@@ -97,6 +98,7 @@ export function ChatComposer(props: {
   const {
     styles,
     isDark,
+    myUserId,
     isDm,
     isGroup,
     isEncryptedChat,
@@ -135,15 +137,21 @@ export function ChatComposer(props: {
 
   const replyToLabel = React.useMemo(() => {
     if (!replyTarget) return '';
+    const sub = typeof replyTarget.userSub === 'string' ? replyTarget.userSub.trim() : '';
+    const origin = messages.find((m) => m && m.id === replyTarget.id);
+    const originSub = origin?.userSub ? String(origin.userSub) : '';
+    const replyingToMe =
+      !!myUserId && (!!sub || !!originSub)
+        ? String(myUserId) === sub || String(myUserId) === originSub
+        : false;
+    if (replyingToMe) return 'yourself';
     const direct = typeof replyTarget.user === 'string' ? replyTarget.user.trim() : '';
     if (direct) return direct;
-    const origin = messages.find((m) => m && m.id === replyTarget.id);
     const fromOrigin = typeof origin?.user === 'string' ? origin.user.trim() : '';
     if (fromOrigin) return fromOrigin;
-    const sub = typeof replyTarget.userSub === 'string' ? replyTarget.userSub.trim() : '';
     if (sub) return `User ${sub.slice(0, 6)}`;
     return 'Unknown user';
-  }, [messages, replyTarget]);
+  }, [messages, myUserId, replyTarget]);
 
   const replyFileMeta = React.useMemo(() => {
     if (!replyTarget) return null;

--- a/frontend/src/features/chat/components/ChatMessageRow.tsx
+++ b/frontend/src/features/chat/components/ChatMessageRow.tsx
@@ -164,7 +164,11 @@ export function ChatMessageRow(props: {
       : undefined;
   const replyToLabel = (() => {
     const sub = item.replyToUserSub ? String(item.replyToUserSub) : '';
-    if (sub && myUserId && String(myUserId) === sub) return 'You';
+    const replyingToMe =
+      !!sub && !!myUserId && String(myUserId) === sub
+        ? true
+        : !!replyOrigin?.userSub && !!myUserId && String(myUserId) === String(replyOrigin.userSub);
+    if (replyingToMe) return isOutgoing ? 'yourself' : 'You';
     const fromOrigin = replyOrigin?.user ? String(replyOrigin.user) : '';
     if (fromOrigin) return fromOrigin;
     if (sub) {

--- a/frontend/src/features/chat/components/ChatMessageRow.tsx
+++ b/frontend/src/features/chat/components/ChatMessageRow.tsx
@@ -165,6 +165,24 @@ export function ChatMessageRow(props: {
   const webConsumeNextReleaseRef = React.useRef(false);
   const swallowNextPressRef = React.useRef(false);
 
+  const handleLongPressMessage = React.useCallback(
+    (e: GestureResponderEvent) => {
+      if (selectionActive) {
+        onToggleSelected();
+        return;
+      }
+      if (isDeleted) return;
+      if (Platform.OS === 'web') {
+        // Critical: consume the imminent release event (touchend/pointerup) so mobile browsers
+        // don't finalize a selection/callout right as the actions menu appears.
+        webConsumeNextReleaseRef.current = true;
+        swallowNextPressRef.current = true;
+      }
+      onLongPressMessage(e);
+    },
+    [isDeleted, onLongPressMessage, onToggleSelected, selectionActive],
+  );
+
   return (
     <Pressable
       onPress={() => {
@@ -179,20 +197,7 @@ export function ChatMessageRow(props: {
         if (inlineEditTargetId && item.id === inlineEditTargetId) return;
         onPressMessage(item);
       }}
-      onLongPress={(e) => {
-        if (selectionActive) {
-          onToggleSelected();
-          return;
-        }
-        if (isDeleted) return;
-        if (Platform.OS === 'web') {
-          // Critical: consume the imminent release event (touchend/pointerup) so mobile browsers
-          // don't finalize a selection/callout right as the actions menu appears.
-          webConsumeNextReleaseRef.current = true;
-          swallowNextPressRef.current = true;
-        }
-        onLongPressMessage(e);
-      }}
+      onLongPress={handleLongPressMessage}
       // Prevent the browser’s native context menu / selection behavior from fighting
       // with our custom long-press message actions on mobile web.
       {...(Platform.OS === 'web'
@@ -661,6 +666,7 @@ export function ChatMessageRow(props: {
                           ]}
                           mentionStyle={styles.mentionText}
                           onOpenUrl={requestOpenLink}
+                          onLongPressLink={handleLongPressMessage}
                         />
                       ) : null}
                       {isEdited || props.seenLabel ? (
@@ -925,6 +931,7 @@ export function ChatMessageRow(props: {
                       ]}
                       mentionStyle={styles.mentionText}
                       onOpenUrl={requestOpenLink}
+                      onLongPressLink={handleLongPressMessage}
                     />
                   )}
 

--- a/frontend/src/features/chat/components/ChatMessageRow.tsx
+++ b/frontend/src/features/chat/components/ChatMessageRow.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
+import React from 'react';
 import type { GestureResponderEvent } from 'react-native';
 import { Image, Platform, Pressable, Text, TextInput, View } from 'react-native';
 
@@ -10,7 +10,11 @@ import type { PublicAvatarProfileLite } from '../../../hooks/usePublicAvatarProf
 import type { ChatScreenStyles } from '../../../screens/ChatScreen.styles';
 import { APP_COLORS, PALETTE, withAlpha } from '../../../theme/colors';
 import type { MediaItem } from '../../../types/media';
-import { fileBrandColorForMedia, fileIconNameForMedia, getPreviewKind } from '../../../utils/mediaKinds';
+import {
+  fileBrandColorForMedia,
+  fileIconNameForMedia,
+  getPreviewKind,
+} from '../../../utils/mediaKinds';
 import type { PendingMediaItem } from '../attachments';
 import {
   normalizeChatMediaList,
@@ -423,69 +427,91 @@ export function ChatMessageRow(props: {
                           if (origin && !origin.deletedAt) {
                             const list = (() => {
                               if (origin.encrypted && origin.decryptedText) {
-                                const dmEnv = parseDmMediaEnvelope(String(origin.decryptedText || ''));
+                                const dmEnv = parseDmMediaEnvelope(
+                                  String(origin.decryptedText || ''),
+                                );
                                 const items = normalizeDmMediaItems(dmEnv);
-                                return items.map(({ media }) =>
-                                  ({
-                                    path: String(media.path || ''),
-                                    thumbPath:
-                                      typeof media.thumbPath === 'string' ? String(media.thumbPath) : undefined,
-                                    kind:
-                                      media.kind === 'video'
-                                        ? 'video'
-                                        : media.kind === 'image'
-                                          ? 'image'
-                                          : 'file',
-                                    contentType:
-                                      typeof media.contentType === 'string' ? String(media.contentType) : undefined,
-                                    thumbContentType:
-                                      typeof media.thumbContentType === 'string'
-                                        ? String(media.thumbContentType)
-                                        : undefined,
-                                    fileName:
-                                      typeof media.fileName === 'string' ? String(media.fileName) : undefined,
-                                    size:
-                                      typeof media.size === 'number' && Number.isFinite(media.size)
-                                        ? media.size
-                                        : undefined,
-                                    durationMs:
-                                      typeof media.durationMs === 'number' && Number.isFinite(media.durationMs)
-                                        ? Math.max(0, Math.floor(media.durationMs))
-                                        : undefined,
-                                  }) as MediaItem,
+                                return items.map(
+                                  ({ media }) =>
+                                    ({
+                                      path: String(media.path || ''),
+                                      thumbPath:
+                                        typeof media.thumbPath === 'string'
+                                          ? String(media.thumbPath)
+                                          : undefined,
+                                      kind:
+                                        media.kind === 'video'
+                                          ? 'video'
+                                          : media.kind === 'image'
+                                            ? 'image'
+                                            : 'file',
+                                      contentType:
+                                        typeof media.contentType === 'string'
+                                          ? String(media.contentType)
+                                          : undefined,
+                                      thumbContentType:
+                                        typeof media.thumbContentType === 'string'
+                                          ? String(media.thumbContentType)
+                                          : undefined,
+                                      fileName:
+                                        typeof media.fileName === 'string'
+                                          ? String(media.fileName)
+                                          : undefined,
+                                      size:
+                                        typeof media.size === 'number' &&
+                                        Number.isFinite(media.size)
+                                          ? media.size
+                                          : undefined,
+                                      durationMs:
+                                        typeof media.durationMs === 'number' &&
+                                        Number.isFinite(media.durationMs)
+                                          ? Math.max(0, Math.floor(media.durationMs))
+                                          : undefined,
+                                    }) as MediaItem,
                                 );
                               }
                               if (origin.groupEncrypted && origin.decryptedText) {
-                                const gEnv = parseGroupMediaEnvelope(String(origin.decryptedText || ''));
+                                const gEnv = parseGroupMediaEnvelope(
+                                  String(origin.decryptedText || ''),
+                                );
                                 const items = normalizeGroupMediaItems(gEnv);
-                                return items.map(({ media }) =>
-                                  ({
-                                    path: String(media.path || ''),
-                                    thumbPath:
-                                      typeof media.thumbPath === 'string' ? String(media.thumbPath) : undefined,
-                                    kind:
-                                      media.kind === 'video'
-                                        ? 'video'
-                                        : media.kind === 'image'
-                                          ? 'image'
-                                          : 'file',
-                                    contentType:
-                                      typeof media.contentType === 'string' ? String(media.contentType) : undefined,
-                                    thumbContentType:
-                                      typeof media.thumbContentType === 'string'
-                                        ? String(media.thumbContentType)
-                                        : undefined,
-                                    fileName:
-                                      typeof media.fileName === 'string' ? String(media.fileName) : undefined,
-                                    size:
-                                      typeof media.size === 'number' && Number.isFinite(media.size)
-                                        ? media.size
-                                        : undefined,
-                                    durationMs:
-                                      typeof media.durationMs === 'number' && Number.isFinite(media.durationMs)
-                                        ? Math.max(0, Math.floor(media.durationMs))
-                                        : undefined,
-                                  }) as MediaItem,
+                                return items.map(
+                                  ({ media }) =>
+                                    ({
+                                      path: String(media.path || ''),
+                                      thumbPath:
+                                        typeof media.thumbPath === 'string'
+                                          ? String(media.thumbPath)
+                                          : undefined,
+                                      kind:
+                                        media.kind === 'video'
+                                          ? 'video'
+                                          : media.kind === 'image'
+                                            ? 'image'
+                                            : 'file',
+                                      contentType:
+                                        typeof media.contentType === 'string'
+                                          ? String(media.contentType)
+                                          : undefined,
+                                      thumbContentType:
+                                        typeof media.thumbContentType === 'string'
+                                          ? String(media.thumbContentType)
+                                          : undefined,
+                                      fileName:
+                                        typeof media.fileName === 'string'
+                                          ? String(media.fileName)
+                                          : undefined,
+                                      size:
+                                        typeof media.size === 'number' &&
+                                        Number.isFinite(media.size)
+                                          ? media.size
+                                          : undefined,
+                                      durationMs:
+                                        typeof media.durationMs === 'number' &&
+                                        Number.isFinite(media.durationMs)
+                                          ? Math.max(0, Math.floor(media.durationMs))
+                                          : undefined,
+                                    }) as MediaItem,
                                 );
                               }
                               const env =
@@ -503,7 +529,7 @@ export function ChatMessageRow(props: {
                               thumbUri =
                                 kind !== 'file'
                                   ? origin.encrypted || origin.groupEncrypted
-                                    ? (first.thumbPath && dmThumbUriByPath[String(first.thumbPath)])
+                                    ? first.thumbPath && dmThumbUriByPath[String(first.thumbPath)]
                                       ? dmThumbUriByPath[String(first.thumbPath)]
                                       : null
                                     : mediaUrlByPath[key]
@@ -562,7 +588,9 @@ export function ChatMessageRow(props: {
                                         color={
                                           isOutgoing
                                             ? withAlpha(PALETTE.white, 0.92)
-                                            : (firstItem ? fileBrandColorForMedia(firstItem) : null) ||
+                                            : (firstItem
+                                                ? fileBrandColorForMedia(firstItem)
+                                                : null) ||
                                               (isDark
                                                 ? APP_COLORS.dark.text.primary
                                                 : APP_COLORS.light.brand.primary)
@@ -595,9 +623,7 @@ export function ChatMessageRow(props: {
                               ]}
                               numberOfLines={1}
                             >
-                              {`Replying to ${
-                                replyToLabel
-                              }`}
+                              {`Replying to ${replyToLabel}`}
                             </Text>
                             <Text
                               style={[
@@ -919,65 +945,83 @@ export function ChatMessageRow(props: {
                         if (origin.encrypted && origin.decryptedText) {
                           const dmEnv = parseDmMediaEnvelope(String(origin.decryptedText || ''));
                           const items = normalizeDmMediaItems(dmEnv);
-                          return items.map(({ media }) =>
-                            ({
-                              path: String(media.path || ''),
-                              thumbPath: typeof media.thumbPath === 'string' ? String(media.thumbPath) : undefined,
-                              kind:
-                                media.kind === 'video'
-                                  ? 'video'
-                                  : media.kind === 'image'
-                                    ? 'image'
-                                    : 'file',
-                              contentType:
-                                typeof media.contentType === 'string' ? String(media.contentType) : undefined,
-                              thumbContentType:
-                                typeof media.thumbContentType === 'string'
-                                  ? String(media.thumbContentType)
-                                  : undefined,
-                              fileName:
-                                typeof media.fileName === 'string' ? String(media.fileName) : undefined,
-                              size:
-                                typeof media.size === 'number' && Number.isFinite(media.size)
-                                  ? media.size
-                                  : undefined,
-                              durationMs:
-                                typeof media.durationMs === 'number' && Number.isFinite(media.durationMs)
-                                  ? Math.max(0, Math.floor(media.durationMs))
-                                  : undefined,
-                            }) as MediaItem,
+                          return items.map(
+                            ({ media }) =>
+                              ({
+                                path: String(media.path || ''),
+                                thumbPath:
+                                  typeof media.thumbPath === 'string'
+                                    ? String(media.thumbPath)
+                                    : undefined,
+                                kind:
+                                  media.kind === 'video'
+                                    ? 'video'
+                                    : media.kind === 'image'
+                                      ? 'image'
+                                      : 'file',
+                                contentType:
+                                  typeof media.contentType === 'string'
+                                    ? String(media.contentType)
+                                    : undefined,
+                                thumbContentType:
+                                  typeof media.thumbContentType === 'string'
+                                    ? String(media.thumbContentType)
+                                    : undefined,
+                                fileName:
+                                  typeof media.fileName === 'string'
+                                    ? String(media.fileName)
+                                    : undefined,
+                                size:
+                                  typeof media.size === 'number' && Number.isFinite(media.size)
+                                    ? media.size
+                                    : undefined,
+                                durationMs:
+                                  typeof media.durationMs === 'number' &&
+                                  Number.isFinite(media.durationMs)
+                                    ? Math.max(0, Math.floor(media.durationMs))
+                                    : undefined,
+                              }) as MediaItem,
                           );
                         }
                         if (origin.groupEncrypted && origin.decryptedText) {
                           const gEnv = parseGroupMediaEnvelope(String(origin.decryptedText || ''));
                           const items = normalizeGroupMediaItems(gEnv);
-                          return items.map(({ media }) =>
-                            ({
-                              path: String(media.path || ''),
-                              thumbPath: typeof media.thumbPath === 'string' ? String(media.thumbPath) : undefined,
-                              kind:
-                                media.kind === 'video'
-                                  ? 'video'
-                                  : media.kind === 'image'
-                                    ? 'image'
-                                    : 'file',
-                              contentType:
-                                typeof media.contentType === 'string' ? String(media.contentType) : undefined,
-                              thumbContentType:
-                                typeof media.thumbContentType === 'string'
-                                  ? String(media.thumbContentType)
-                                  : undefined,
-                              fileName:
-                                typeof media.fileName === 'string' ? String(media.fileName) : undefined,
-                              size:
-                                typeof media.size === 'number' && Number.isFinite(media.size)
-                                  ? media.size
-                                  : undefined,
-                              durationMs:
-                                typeof media.durationMs === 'number' && Number.isFinite(media.durationMs)
-                                  ? Math.max(0, Math.floor(media.durationMs))
-                                  : undefined,
-                            }) as MediaItem,
+                          return items.map(
+                            ({ media }) =>
+                              ({
+                                path: String(media.path || ''),
+                                thumbPath:
+                                  typeof media.thumbPath === 'string'
+                                    ? String(media.thumbPath)
+                                    : undefined,
+                                kind:
+                                  media.kind === 'video'
+                                    ? 'video'
+                                    : media.kind === 'image'
+                                      ? 'image'
+                                      : 'file',
+                                contentType:
+                                  typeof media.contentType === 'string'
+                                    ? String(media.contentType)
+                                    : undefined,
+                                thumbContentType:
+                                  typeof media.thumbContentType === 'string'
+                                    ? String(media.thumbContentType)
+                                    : undefined,
+                                fileName:
+                                  typeof media.fileName === 'string'
+                                    ? String(media.fileName)
+                                    : undefined,
+                                size:
+                                  typeof media.size === 'number' && Number.isFinite(media.size)
+                                    ? media.size
+                                    : undefined,
+                                durationMs:
+                                  typeof media.durationMs === 'number' &&
+                                  Number.isFinite(media.durationMs)
+                                    ? Math.max(0, Math.floor(media.durationMs))
+                                    : undefined,
+                              }) as MediaItem,
                           );
                         }
                         const env =
@@ -995,7 +1039,7 @@ export function ChatMessageRow(props: {
                         thumbUri =
                           kind !== 'file'
                             ? origin.encrypted || origin.groupEncrypted
-                              ? (first.thumbPath && dmThumbUriByPath[String(first.thumbPath)])
+                              ? first.thumbPath && dmThumbUriByPath[String(first.thumbPath)]
                                 ? dmThumbUriByPath[String(first.thumbPath)]
                                 : null
                               : mediaUrlByPath[key]

--- a/frontend/src/features/chat/components/ChatScreenMain.tsx
+++ b/frontend/src/features/chat/components/ChatScreenMain.tsx
@@ -547,6 +547,7 @@ export function ChatScreenMain({
             <ChatComposer
               styles={styles}
               isDark={isDark}
+              myUserId={header.myUserId}
               isDm={composer.isDm}
               isGroup={composer.isGroup}
               isEncryptedChat={composer.isEncryptedChat}

--- a/frontend/src/features/chat/components/ChatScreenOverlays.tsx
+++ b/frontend/src/features/chat/components/ChatScreenOverlays.tsx
@@ -177,6 +177,7 @@ export type ChatScreenOverlaysProps = {
   normalizeUser: (v: unknown) => string;
   mediaUrlByPath: Record<string, string>;
   dmThumbUriByPath: Record<string, string>;
+  messageListData: ChatMessage[];
   quickReactions: string[];
   blockedSubsSet: Set<string>;
   onBlockUserSub?: (blockedSub: string, label?: string) => void | Promise<void>;
@@ -321,6 +322,7 @@ export function ChatScreenOverlays(props: ChatScreenOverlaysProps): React.JSX.El
     normalizeUser,
     mediaUrlByPath,
     dmThumbUriByPath,
+    messageListData,
     quickReactions,
     blockedSubsSet,
     onBlockUserSub,
@@ -531,6 +533,8 @@ export function ChatScreenOverlays(props: ChatScreenOverlaysProps): React.JSX.El
         mediaUrlByPath={mediaUrlByPath}
         dmThumbUriByPath={dmThumbUriByPath}
         quickReactions={quickReactions}
+        nameBySub={nameBySub}
+        messageListData={messageListData}
         blockedSubsSet={blockedSubsSet}
         onBlockUserSub={onBlockUserSub}
         uiConfirm={uiConfirm}

--- a/frontend/src/features/chat/components/MessageActionMenuModal.tsx
+++ b/frontend/src/features/chat/components/MessageActionMenuModal.tsx
@@ -359,9 +359,13 @@ export function MessageActionMenuModal({
 
                 if (!hasMedia) {
                   const showReply =
-                    !t.deletedAt && !!t.replyToMessageId && String(t.replyToPreview || '').trim().length > 0;
+                    !t.deletedAt &&
+                    !!t.replyToMessageId &&
+                    String(t.replyToPreview || '').trim().length > 0;
                   const replyKind =
-                    t.replyToMediaKind === 'image' || t.replyToMediaKind === 'video' || t.replyToMediaKind === 'file'
+                    t.replyToMediaKind === 'image' ||
+                    t.replyToMediaKind === 'video' ||
+                    t.replyToMediaKind === 'file'
                       ? t.replyToMediaKind
                       : null;
                   const replyCount =
@@ -422,10 +426,10 @@ export function MessageActionMenuModal({
                                       isOutgoing
                                         ? withAlpha(PALETTE.white, 0.92)
                                         : fileBrandColorForMedia({
-                                              kind: 'file',
-                                              contentType: t.replyToMediaContentType,
-                                              fileName: t.replyToMediaFileName,
-                                            }) ||
+                                            kind: 'file',
+                                            contentType: t.replyToMediaContentType,
+                                            fileName: t.replyToMediaFileName,
+                                          }) ||
                                           (isDark
                                             ? styles.replySnippetLabelIncomingDark?.color
                                             : styles.replySnippetLabelIncoming?.color)
@@ -441,7 +445,9 @@ export function MessageActionMenuModal({
                               )}
                               {replyCount > 1 ? (
                                 <View style={styles.replyThumbCountBadge}>
-                                  <Text style={styles.replyThumbCountText}>{`+${replyCount - 1}`}</Text>
+                                  <Text
+                                    style={styles.replyThumbCountText}
+                                  >{`+${replyCount - 1}`}</Text>
                                 </View>
                               ) : null}
                             </View>

--- a/frontend/src/features/chat/getCopyableMessageText.ts
+++ b/frontend/src/features/chat/getCopyableMessageText.ts
@@ -35,15 +35,15 @@ export function getCopyableMessageText(args: { msg: ChatMessage; isDm: boolean }
     if (encEnv) {
       text = String(encEnv.text || '');
     } else {
-    const dmEnv = parseDmMediaEnvelope(plain);
-    const dmItems = dmEnv ? normalizeDmMediaItems(dmEnv) : [];
-    const gEnv = parseGroupMediaEnvelope(plain);
-    const gItems = gEnv ? normalizeGroupMediaItems(gEnv) : [];
-    if (dmItems.length || gItems.length) {
-      text = String((dmEnv?.caption ?? gEnv?.caption) || '');
-    } else {
-      text = plain;
-    }
+      const dmEnv = parseDmMediaEnvelope(plain);
+      const dmItems = dmEnv ? normalizeDmMediaItems(dmEnv) : [];
+      const gEnv = parseGroupMediaEnvelope(plain);
+      const gItems = gEnv ? normalizeGroupMediaItems(gEnv) : [];
+      if (dmItems.length || gItems.length) {
+        text = String((dmEnv?.caption ?? gEnv?.caption) || '');
+      } else {
+        text = plain;
+      }
     }
   } else {
     // Plain chats: channel/global can have a JSON envelope for media attachments.

--- a/frontend/src/features/chat/getCopyableMessageText.ts
+++ b/frontend/src/features/chat/getCopyableMessageText.ts
@@ -4,6 +4,7 @@ import {
   normalizeGroupMediaItems,
   parseChatEnvelope,
   parseDmMediaEnvelope,
+  parseEncryptedTextEnvelope,
   parseGroupMediaEnvelope,
 } from './parsers';
 import type { ChatMessage } from './types';
@@ -30,6 +31,10 @@ export function getCopyableMessageText(args: { msg: ChatMessage; isDm: boolean }
   // or plain text.
   if (t.encrypted || t.groupEncrypted) {
     const plain = String(t.decryptedText || '');
+    const encEnv = parseEncryptedTextEnvelope(plain);
+    if (encEnv) {
+      text = String(encEnv.text || '');
+    } else {
     const dmEnv = parseDmMediaEnvelope(plain);
     const dmItems = dmEnv ? normalizeDmMediaItems(dmEnv) : [];
     const gEnv = parseGroupMediaEnvelope(plain);
@@ -38,6 +43,7 @@ export function getCopyableMessageText(args: { msg: ChatMessage; isDm: boolean }
       text = String((dmEnv?.caption ?? gEnv?.caption) || '');
     } else {
       text = plain;
+    }
     }
   } else {
     // Plain chats: channel/global can have a JSON envelope for media attachments.

--- a/frontend/src/features/chat/handleWsMessage.ts
+++ b/frontend/src/features/chat/handleWsMessage.ts
@@ -6,6 +6,7 @@ import { applyGroupMembershipSystemEventToMe } from './applyMembershipToMe';
 import { buildIncomingChatMessageFromWsPayload } from './buildIncomingMessage';
 import { buildSystemChatMessageFromPayload } from './buildSystemMessage';
 import { isMembershipSystemKind } from './membershipKinds';
+import { parseEncryptedTextEnvelope } from './parsers';
 import type {
   ChatMessage,
   DmMediaEnvelope,
@@ -396,11 +397,20 @@ export function handleChatWsMessage(opts: {
             } catch {
               caption = null;
             }
+            const encEnv = parseEncryptedTextEnvelope(plaintext);
             return {
               ...nextBase,
               decryptedText: plaintext,
               groupKeyHex,
-              text: caption != null ? caption : plaintext,
+              text: encEnv ? String(encEnv.text || '') : caption != null ? caption : plaintext,
+              replyToCreatedAt: encEnv?.replyToCreatedAt,
+              replyToMessageId: encEnv?.replyToMessageId,
+              replyToUserSub: encEnv?.replyToUserSub,
+              replyToPreview: encEnv?.replyToPreview,
+              replyToMediaKind: encEnv?.replyToMediaKind,
+              replyToMediaCount: encEnv?.replyToMediaCount,
+              replyToMediaContentType: encEnv?.replyToMediaContentType,
+              replyToMediaFileName: encEnv?.replyToMediaFileName,
               decryptFailed: false,
             };
           }

--- a/frontend/src/features/chat/parsers.ts
+++ b/frontend/src/features/chat/parsers.ts
@@ -5,6 +5,7 @@ import type {
   DmMediaEnvelope,
   DmMediaEnvelopeV1,
   DmMediaEnvelopeV2,
+  EncryptedTextEnvelopeV1,
   GroupMediaEnvelope,
   GroupMediaEnvelopeV1,
   GroupMediaEnvelopeV2,
@@ -18,6 +19,20 @@ export const parseChatEnvelope = (raw: string): ChatEnvelope | null => {
     const rec = obj as Record<string, unknown>;
     if (rec.type !== 'chat') return null;
     return rec as ChatEnvelope;
+  } catch {
+    return null;
+  }
+};
+
+export const parseEncryptedTextEnvelope = (raw: string): EncryptedTextEnvelopeV1 | null => {
+  if (!raw) return null;
+  try {
+    const obj: unknown = JSON.parse(raw);
+    if (!obj || typeof obj !== 'object') return null;
+    const rec = obj as Record<string, unknown>;
+    if (rec.type !== 'enc_text_v1' || rec.v !== 1) return null;
+    if (typeof rec.text !== 'string') return null;
+    return rec as EncryptedTextEnvelopeV1;
   } catch {
     return null;
   }

--- a/frontend/src/features/chat/types.ts
+++ b/frontend/src/features/chat/types.ts
@@ -49,12 +49,17 @@ export type ChatMessage = {
   editedAt?: number; // epoch ms
   deletedAt?: number; // epoch ms
   deletedBySub?: string;
-  // Channels (plaintext) metadata
+  // Reply metadata (channels: plaintext payload; DMs/GDMs: extracted from decrypted envelope)
   mentions?: string[];
   replyToCreatedAt?: number;
   replyToMessageId?: string;
   replyToUserSub?: string;
   replyToPreview?: string;
+  // Optional extra metadata to render better reply previews (especially in encrypted chats)
+  replyToMediaKind?: MediaKind;
+  replyToMediaCount?: number;
+  replyToMediaContentType?: string;
+  replyToMediaFileName?: string;
   reactions?: ReactionMap;
   // Backward-compat: historically we supported only a single attachment per message.
   // New messages can include multiple attachments; use `mediaList` when present.
@@ -69,6 +74,15 @@ export type DmMediaEnvelopeV1 = {
   type: 'dm_media_v1';
   v: 1;
   caption?: string;
+  // Optional reply metadata (encrypted in DM text)
+  replyToCreatedAt?: number;
+  replyToMessageId?: string;
+  replyToUserSub?: string;
+  replyToPreview?: string;
+  replyToMediaKind?: MediaKind;
+  replyToMediaCount?: number;
+  replyToMediaContentType?: string;
+  replyToMediaFileName?: string;
   media: {
     kind: MediaKind;
     contentType?: string;
@@ -91,6 +105,15 @@ export type DmMediaEnvelopeV2 = {
   type: 'dm_media_v2';
   v: 2;
   caption?: string;
+  // Optional reply metadata (encrypted in DM text)
+  replyToCreatedAt?: number;
+  replyToMessageId?: string;
+  replyToUserSub?: string;
+  replyToPreview?: string;
+  replyToMediaKind?: MediaKind;
+  replyToMediaCount?: number;
+  replyToMediaContentType?: string;
+  replyToMediaFileName?: string;
   // Each item wraps its own per-attachment file key (Signal-style).
   items: Array<{
     media: DmMediaEnvelopeV1['media'];
@@ -107,6 +130,15 @@ export type GroupMediaEnvelopeV1 = {
   type: 'gdm_media_v1';
   v: 1;
   caption?: string;
+  // Optional reply metadata (encrypted in group text)
+  replyToCreatedAt?: number;
+  replyToMessageId?: string;
+  replyToUserSub?: string;
+  replyToPreview?: string;
+  replyToMediaKind?: MediaKind;
+  replyToMediaCount?: number;
+  replyToMediaContentType?: string;
+  replyToMediaFileName?: string;
   media: DmMediaEnvelopeV1['media'];
   wrap: DmMediaEnvelopeV1['wrap']; // aesGcmEncryptBytes(messageKey, fileKey)
 };
@@ -115,7 +147,30 @@ export type GroupMediaEnvelopeV2 = {
   type: 'gdm_media_v2';
   v: 2;
   caption?: string;
+  // Optional reply metadata (encrypted in group text)
+  replyToCreatedAt?: number;
+  replyToMessageId?: string;
+  replyToUserSub?: string;
+  replyToPreview?: string;
+  replyToMediaKind?: MediaKind;
+  replyToMediaCount?: number;
+  replyToMediaContentType?: string;
+  replyToMediaFileName?: string;
   items: Array<{ media: DmMediaEnvelopeV1['media']; wrap: DmMediaEnvelopeV1['wrap'] }>;
+};
+
+export type EncryptedTextEnvelopeV1 = {
+  type: 'enc_text_v1';
+  v: 1;
+  text: string;
+  replyToCreatedAt?: number;
+  replyToMessageId?: string;
+  replyToUserSub?: string;
+  replyToPreview?: string;
+  replyToMediaKind?: MediaKind;
+  replyToMediaCount?: number;
+  replyToMediaContentType?: string;
+  replyToMediaFileName?: string;
 };
 
 export type GroupMediaEnvelope = GroupMediaEnvelopeV1 | GroupMediaEnvelopeV2;

--- a/frontend/src/features/chat/useChatAutoDecrypt.ts
+++ b/frontend/src/features/chat/useChatAutoDecrypt.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import type { MediaItem } from '../../types/media';
 import type { ChatMessage, DmMediaEnvelope, DmMediaEnvelopeV1, GroupMediaEnvelope } from './types';
+import { parseEncryptedTextEnvelope } from './parsers';
 
 type DmMediaItem = { media: DmMediaEnvelopeV1['media'] };
 type GroupMediaItem = { media: DmMediaEnvelopeV1['media'] };
@@ -68,6 +69,7 @@ export function useChatAutoDecrypt(opts: {
         const groupDec = m.groupEncrypted ? decryptGroupForDisplay(m) : null;
         const plaintext = groupDec ? groupDec.plaintext : decryptForDisplay(m);
         changed = true;
+        const encEnv = parseEncryptedTextEnvelope(String(plaintext || ''));
         const dmEnv = isDm ? parseDmMediaEnvelope(plaintext) : null;
         const gEnv = isGroup ? parseGroupMediaEnvelope(plaintext) : null;
         const dmItems = dmEnv ? normalizeDmMediaItems(dmEnv) : [];
@@ -90,7 +92,23 @@ export function useChatAutoDecrypt(opts: {
             ...m,
             decryptedText: plaintext,
             groupKeyHex: groupDec ? groupDec.messageKeyHex : m.groupKeyHex,
-            text: dmEnv ? (dmEnv.caption ?? '') : gEnv ? (gEnv.caption ?? '') : plaintext,
+            text: encEnv
+              ? String(encEnv.text || '')
+              : dmEnv
+                ? (dmEnv.caption ?? '')
+                : gEnv
+                  ? (gEnv.caption ?? '')
+                  : plaintext,
+            replyToCreatedAt: encEnv?.replyToCreatedAt ?? dmEnv?.replyToCreatedAt ?? gEnv?.replyToCreatedAt,
+            replyToMessageId: encEnv?.replyToMessageId ?? dmEnv?.replyToMessageId ?? gEnv?.replyToMessageId,
+            replyToUserSub: encEnv?.replyToUserSub ?? dmEnv?.replyToUserSub ?? gEnv?.replyToUserSub,
+            replyToPreview: encEnv?.replyToPreview ?? dmEnv?.replyToPreview ?? gEnv?.replyToPreview,
+            replyToMediaKind: encEnv?.replyToMediaKind ?? dmEnv?.replyToMediaKind ?? gEnv?.replyToMediaKind,
+            replyToMediaCount: encEnv?.replyToMediaCount ?? dmEnv?.replyToMediaCount ?? gEnv?.replyToMediaCount,
+            replyToMediaContentType:
+              encEnv?.replyToMediaContentType ?? dmEnv?.replyToMediaContentType ?? gEnv?.replyToMediaContentType,
+            replyToMediaFileName:
+              encEnv?.replyToMediaFileName ?? dmEnv?.replyToMediaFileName ?? gEnv?.replyToMediaFileName,
             media: mediaList.length ? mediaList[0] : m.media,
             mediaList: mediaList.length ? mediaList : undefined,
             expiresAt,
@@ -101,7 +119,23 @@ export function useChatAutoDecrypt(opts: {
           ...m,
           decryptedText: plaintext,
           groupKeyHex: groupDec ? groupDec.messageKeyHex : m.groupKeyHex,
-          text: dmEnv ? (dmEnv.caption ?? '') : gEnv ? (gEnv.caption ?? '') : plaintext,
+          text: encEnv
+            ? String(encEnv.text || '')
+            : dmEnv
+              ? (dmEnv.caption ?? '')
+              : gEnv
+                ? (gEnv.caption ?? '')
+                : plaintext,
+          replyToCreatedAt: encEnv?.replyToCreatedAt ?? dmEnv?.replyToCreatedAt ?? gEnv?.replyToCreatedAt,
+          replyToMessageId: encEnv?.replyToMessageId ?? dmEnv?.replyToMessageId ?? gEnv?.replyToMessageId,
+          replyToUserSub: encEnv?.replyToUserSub ?? dmEnv?.replyToUserSub ?? gEnv?.replyToUserSub,
+          replyToPreview: encEnv?.replyToPreview ?? dmEnv?.replyToPreview ?? gEnv?.replyToPreview,
+          replyToMediaKind: encEnv?.replyToMediaKind ?? dmEnv?.replyToMediaKind ?? gEnv?.replyToMediaKind,
+          replyToMediaCount: encEnv?.replyToMediaCount ?? dmEnv?.replyToMediaCount ?? gEnv?.replyToMediaCount,
+          replyToMediaContentType:
+            encEnv?.replyToMediaContentType ?? dmEnv?.replyToMediaContentType ?? gEnv?.replyToMediaContentType,
+          replyToMediaFileName:
+            encEnv?.replyToMediaFileName ?? dmEnv?.replyToMediaFileName ?? gEnv?.replyToMediaFileName,
           media: mediaList.length ? mediaList[0] : m.media,
           mediaList: mediaList.length ? mediaList : undefined,
         };

--- a/frontend/src/features/chat/useChatAutoDecrypt.ts
+++ b/frontend/src/features/chat/useChatAutoDecrypt.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
 import type { MediaItem } from '../../types/media';
-import type { ChatMessage, DmMediaEnvelope, DmMediaEnvelopeV1, GroupMediaEnvelope } from './types';
 import { parseEncryptedTextEnvelope } from './parsers';
+import type { ChatMessage, DmMediaEnvelope, DmMediaEnvelopeV1, GroupMediaEnvelope } from './types';
 
 type DmMediaItem = { media: DmMediaEnvelopeV1['media'] };
 type GroupMediaItem = { media: DmMediaEnvelopeV1['media'] };
@@ -99,16 +99,24 @@ export function useChatAutoDecrypt(opts: {
                 : gEnv
                   ? (gEnv.caption ?? '')
                   : plaintext,
-            replyToCreatedAt: encEnv?.replyToCreatedAt ?? dmEnv?.replyToCreatedAt ?? gEnv?.replyToCreatedAt,
-            replyToMessageId: encEnv?.replyToMessageId ?? dmEnv?.replyToMessageId ?? gEnv?.replyToMessageId,
+            replyToCreatedAt:
+              encEnv?.replyToCreatedAt ?? dmEnv?.replyToCreatedAt ?? gEnv?.replyToCreatedAt,
+            replyToMessageId:
+              encEnv?.replyToMessageId ?? dmEnv?.replyToMessageId ?? gEnv?.replyToMessageId,
             replyToUserSub: encEnv?.replyToUserSub ?? dmEnv?.replyToUserSub ?? gEnv?.replyToUserSub,
             replyToPreview: encEnv?.replyToPreview ?? dmEnv?.replyToPreview ?? gEnv?.replyToPreview,
-            replyToMediaKind: encEnv?.replyToMediaKind ?? dmEnv?.replyToMediaKind ?? gEnv?.replyToMediaKind,
-            replyToMediaCount: encEnv?.replyToMediaCount ?? dmEnv?.replyToMediaCount ?? gEnv?.replyToMediaCount,
+            replyToMediaKind:
+              encEnv?.replyToMediaKind ?? dmEnv?.replyToMediaKind ?? gEnv?.replyToMediaKind,
+            replyToMediaCount:
+              encEnv?.replyToMediaCount ?? dmEnv?.replyToMediaCount ?? gEnv?.replyToMediaCount,
             replyToMediaContentType:
-              encEnv?.replyToMediaContentType ?? dmEnv?.replyToMediaContentType ?? gEnv?.replyToMediaContentType,
+              encEnv?.replyToMediaContentType ??
+              dmEnv?.replyToMediaContentType ??
+              gEnv?.replyToMediaContentType,
             replyToMediaFileName:
-              encEnv?.replyToMediaFileName ?? dmEnv?.replyToMediaFileName ?? gEnv?.replyToMediaFileName,
+              encEnv?.replyToMediaFileName ??
+              dmEnv?.replyToMediaFileName ??
+              gEnv?.replyToMediaFileName,
             media: mediaList.length ? mediaList[0] : m.media,
             mediaList: mediaList.length ? mediaList : undefined,
             expiresAt,
@@ -126,16 +134,24 @@ export function useChatAutoDecrypt(opts: {
               : gEnv
                 ? (gEnv.caption ?? '')
                 : plaintext,
-          replyToCreatedAt: encEnv?.replyToCreatedAt ?? dmEnv?.replyToCreatedAt ?? gEnv?.replyToCreatedAt,
-          replyToMessageId: encEnv?.replyToMessageId ?? dmEnv?.replyToMessageId ?? gEnv?.replyToMessageId,
+          replyToCreatedAt:
+            encEnv?.replyToCreatedAt ?? dmEnv?.replyToCreatedAt ?? gEnv?.replyToCreatedAt,
+          replyToMessageId:
+            encEnv?.replyToMessageId ?? dmEnv?.replyToMessageId ?? gEnv?.replyToMessageId,
           replyToUserSub: encEnv?.replyToUserSub ?? dmEnv?.replyToUserSub ?? gEnv?.replyToUserSub,
           replyToPreview: encEnv?.replyToPreview ?? dmEnv?.replyToPreview ?? gEnv?.replyToPreview,
-          replyToMediaKind: encEnv?.replyToMediaKind ?? dmEnv?.replyToMediaKind ?? gEnv?.replyToMediaKind,
-          replyToMediaCount: encEnv?.replyToMediaCount ?? dmEnv?.replyToMediaCount ?? gEnv?.replyToMediaCount,
+          replyToMediaKind:
+            encEnv?.replyToMediaKind ?? dmEnv?.replyToMediaKind ?? gEnv?.replyToMediaKind,
+          replyToMediaCount:
+            encEnv?.replyToMediaCount ?? dmEnv?.replyToMediaCount ?? gEnv?.replyToMediaCount,
           replyToMediaContentType:
-            encEnv?.replyToMediaContentType ?? dmEnv?.replyToMediaContentType ?? gEnv?.replyToMediaContentType,
+            encEnv?.replyToMediaContentType ??
+            dmEnv?.replyToMediaContentType ??
+            gEnv?.replyToMediaContentType,
           replyToMediaFileName:
-            encEnv?.replyToMediaFileName ?? dmEnv?.replyToMediaFileName ?? gEnv?.replyToMediaFileName,
+            encEnv?.replyToMediaFileName ??
+            dmEnv?.replyToMediaFileName ??
+            gEnv?.replyToMediaFileName,
           media: mediaList.length ? mediaList[0] : m.media,
           mediaList: mediaList.length ? mediaList : undefined,
         };

--- a/frontend/src/features/chat/useChatPressToDecrypt.ts
+++ b/frontend/src/features/chat/useChatPressToDecrypt.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
 import type { MediaItem } from '../../types/media';
-import type { ChatMessage, DmMediaEnvelope, DmMediaEnvelopeV1, GroupMediaEnvelope } from './types';
 import { parseEncryptedTextEnvelope } from './parsers';
+import type { ChatMessage, DmMediaEnvelope, DmMediaEnvelopeV1, GroupMediaEnvelope } from './types';
 
 function getErrorMessage(err: unknown): string {
   if (err instanceof Error) return err.message || 'Unknown error';
@@ -118,7 +118,9 @@ export function useChatPressToDecrypt(opts: {
                   replyToMediaKind:
                     encEnv?.replyToMediaKind ?? dmEnv?.replyToMediaKind ?? gEnv?.replyToMediaKind,
                   replyToMediaCount:
-                    encEnv?.replyToMediaCount ?? dmEnv?.replyToMediaCount ?? gEnv?.replyToMediaCount,
+                    encEnv?.replyToMediaCount ??
+                    dmEnv?.replyToMediaCount ??
+                    gEnv?.replyToMediaCount,
                   replyToMediaContentType:
                     encEnv?.replyToMediaContentType ??
                     dmEnv?.replyToMediaContentType ??

--- a/frontend/src/features/chat/useChatPressToDecrypt.ts
+++ b/frontend/src/features/chat/useChatPressToDecrypt.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import type { MediaItem } from '../../types/media';
 import type { ChatMessage, DmMediaEnvelope, DmMediaEnvelopeV1, GroupMediaEnvelope } from './types';
+import { parseEncryptedTextEnvelope } from './parsers';
 
 function getErrorMessage(err: unknown): string {
   if (err instanceof Error) return err.message || 'Unknown error';
@@ -70,6 +71,7 @@ export function useChatPressToDecrypt(opts: {
         const readAt = Math.floor(Date.now() / 1000);
         const groupDec = msg.groupEncrypted ? decryptGroupForDisplay(msg) : null;
         const plaintext = groupDec ? String(groupDec.plaintext || '') : decryptForDisplay(msg);
+        const encEnv = parseEncryptedTextEnvelope(String(plaintext || ''));
 
         const dmEnv = isDm && !groupDec ? parseDmMediaEnvelope(plaintext) : null;
         const dmItems = dmEnv ? normalizeDmMediaItems(dmEnv) : [];
@@ -98,7 +100,33 @@ export function useChatPressToDecrypt(opts: {
                   ...m,
                   decryptedText: plaintext,
                   groupKeyHex: groupDec ? String(groupDec.messageKeyHex || '') : m.groupKeyHex,
-                  text: dmEnv ? (dmEnv.caption ?? '') : gEnv ? (gEnv.caption ?? '') : plaintext,
+                  text: encEnv
+                    ? String(encEnv.text || '')
+                    : dmEnv
+                      ? (dmEnv.caption ?? '')
+                      : gEnv
+                        ? (gEnv.caption ?? '')
+                        : plaintext,
+                  replyToCreatedAt:
+                    encEnv?.replyToCreatedAt ?? dmEnv?.replyToCreatedAt ?? gEnv?.replyToCreatedAt,
+                  replyToMessageId:
+                    encEnv?.replyToMessageId ?? dmEnv?.replyToMessageId ?? gEnv?.replyToMessageId,
+                  replyToUserSub:
+                    encEnv?.replyToUserSub ?? dmEnv?.replyToUserSub ?? gEnv?.replyToUserSub,
+                  replyToPreview:
+                    encEnv?.replyToPreview ?? dmEnv?.replyToPreview ?? gEnv?.replyToPreview,
+                  replyToMediaKind:
+                    encEnv?.replyToMediaKind ?? dmEnv?.replyToMediaKind ?? gEnv?.replyToMediaKind,
+                  replyToMediaCount:
+                    encEnv?.replyToMediaCount ?? dmEnv?.replyToMediaCount ?? gEnv?.replyToMediaCount,
+                  replyToMediaContentType:
+                    encEnv?.replyToMediaContentType ??
+                    dmEnv?.replyToMediaContentType ??
+                    gEnv?.replyToMediaContentType,
+                  replyToMediaFileName:
+                    encEnv?.replyToMediaFileName ??
+                    dmEnv?.replyToMediaFileName ??
+                    gEnv?.replyToMediaFileName,
                   media: mediaList.length ? mediaList[0] : m.media,
                   mediaList: mediaList.length ? mediaList : undefined,
                   expiresAt:

--- a/frontend/src/features/chat/useChatReplyActions.ts
+++ b/frontend/src/features/chat/useChatReplyActions.ts
@@ -91,6 +91,8 @@ export function useChatReplyActions(opts: {
       } catch {
         // ignore
       }
+      // Files (PDF/DOC/etc) can't render in <Image>. Force no thumb so UI uses placeholders.
+      if (mediaKind === 'file') mediaThumbUri = null;
 
       if (target.encrypted || target.groupEncrypted) {
         // For encrypted messages, only allow reply preview if we already decrypted.
@@ -120,6 +122,8 @@ export function useChatReplyActions(opts: {
         mediaKind,
         mediaCount,
         mediaThumbUri: typeof mediaThumbUri === 'string' ? mediaThumbUri : null,
+        mediaContentType: mediaContentType ? String(mediaContentType) : undefined,
+        mediaFileName: mediaFileName ? String(mediaFileName) : undefined,
       });
       closeMessageActions();
       try {

--- a/frontend/src/features/chat/useChatSendActions.ts
+++ b/frontend/src/features/chat/useChatSendActions.ts
@@ -21,6 +21,8 @@ export type ReplyTarget = {
   mediaKind?: 'image' | 'video' | 'file';
   mediaCount?: number;
   mediaThumbUri?: string | null;
+  mediaContentType?: string;
+  mediaFileName?: string;
 };
 
 type TextInputLike = { clear?: () => void };

--- a/frontend/src/features/chat/useChatTtlPickerState.ts
+++ b/frontend/src/features/chat/useChatTtlPickerState.ts
@@ -4,8 +4,8 @@ export function useChatTtlPickerState() {
   const TTL_OPTIONS = React.useMemo(
     () => [
       { label: 'Off', seconds: 0 },
+      { label: '15 seconds', seconds: 15 },
       { label: '5 min', seconds: 5 * 60 },
-      { label: '30 min', seconds: 30 * 60 },
       { label: '1 hour', seconds: 60 * 60 },
       { label: '6 hours', seconds: 6 * 60 * 60 },
       { label: '1 day', seconds: 24 * 60 * 60 },

--- a/frontend/src/screens/ChatScreen.styles.ts
+++ b/frontend/src/screens/ChatScreen.styles.ts
@@ -798,16 +798,15 @@ export const styles = StyleSheet.create({
     flex: 1,
     flexBasis: 0,
     minWidth: 0,
-    height: 44,
-    // Explicit text metrics + vertical alignment to prevent clipping on iOS/Android.
+    minHeight: 44,
+    // Explicit text metrics + padding for stable cross-platform layout (single + multi-line).
     fontSize: 15,
-    // Use a lineHeight matching the control height for stable vertical centering.
-    lineHeight: 44,
+    lineHeight: 20,
     paddingHorizontal: 12,
-    paddingVertical: 0,
+    paddingVertical: 10,
     ...(Platform.OS === 'android'
       ? ({
-          textAlignVertical: 'center',
+          textAlignVertical: 'top',
           includeFontPadding: false,
         } as const)
       : {}),

--- a/frontend/src/screens/ChatScreen.tsx
+++ b/frontend/src/screens/ChatScreen.tsx
@@ -2144,6 +2144,7 @@ export default function ChatScreen({
     normalizeUser,
     mediaUrlByPath,
     dmThumbUriByPath,
+    messageListData,
     quickReactions: [...QUICK_REACTIONS],
     blockedSubsSet,
     onBlockUserSub,


### PR DESCRIPTION
Richtext URLs no longer intercepting long presses for message options. Single press still same open URL flow.

Chat Composer grows vertically in size for longer messages. Enter is new line on mobile, shift + enter is new line on web. Enter is still send on web.

Fixed Replies as well as attachments for replies, and for DMs.

30 seconds to TTL, remove 30 min
