### PR TITLE
Fix googel play warnings

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -79,6 +79,8 @@
           "icon": "./assets/icons/notification-icon.png"
         }
       ],
+      "./plugins/withNoBootCompletedNotifications",
+      "./plugins/withNoMlkitCodeScanner",
       "expo-audio"
     ],
     "owner": "eperry2688"

--- a/frontend/plugins/withNoBootCompletedNotifications.js
+++ b/frontend/plugins/withNoBootCompletedNotifications.js
@@ -11,7 +11,7 @@ function removeUsesPermission(manifest, permissionName) {
   const perms = manifest?.manifest?.['uses-permission'];
   if (!Array.isArray(perms)) return;
   manifest.manifest['uses-permission'] = perms.filter(
-    (p) => p?.$?.['android:name'] !== permissionName
+    (p) => p?.$?.['android:name'] !== permissionName,
   );
 }
 
@@ -23,7 +23,7 @@ function removeBootActionsFromNotificationsReceiver(manifest) {
   if (!Array.isArray(receivers)) return;
 
   const target = receivers.find(
-    (r) => r?.$?.['android:name'] === 'expo.modules.notifications.service.NotificationsService'
+    (r) => r?.$?.['android:name'] === 'expo.modules.notifications.service.NotificationsService',
   );
   if (!target) return;
 
@@ -53,4 +53,3 @@ module.exports = function withNoBootCompletedNotifications(config) {
     return config;
   });
 };
-

--- a/frontend/plugins/withNoBootCompletedNotifications.js
+++ b/frontend/plugins/withNoBootCompletedNotifications.js
@@ -1,0 +1,56 @@
+const { withAndroidManifest } = require('@expo/config-plugins');
+
+const BOOT_ACTIONS = new Set([
+  'android.intent.action.BOOT_COMPLETED',
+  'android.intent.action.REBOOT',
+  'android.intent.action.QUICKBOOT_POWERON',
+  'com.htc.intent.action.QUICKBOOT_POWERON',
+]);
+
+function removeUsesPermission(manifest, permissionName) {
+  const perms = manifest?.manifest?.['uses-permission'];
+  if (!Array.isArray(perms)) return;
+  manifest.manifest['uses-permission'] = perms.filter(
+    (p) => p?.$?.['android:name'] !== permissionName
+  );
+}
+
+function removeBootActionsFromNotificationsReceiver(manifest) {
+  const app = manifest?.manifest?.application?.[0];
+  if (!app) return;
+
+  const receivers = app.receiver;
+  if (!Array.isArray(receivers)) return;
+
+  const target = receivers.find(
+    (r) => r?.$?.['android:name'] === 'expo.modules.notifications.service.NotificationsService'
+  );
+  if (!target) return;
+
+  const intentFilters = target['intent-filter'];
+  if (!Array.isArray(intentFilters)) return;
+
+  for (const f of intentFilters) {
+    const actions = f?.action;
+    if (!Array.isArray(actions)) continue;
+    f.action = actions.filter((a) => !BOOT_ACTIONS.has(a?.$?.['android:name']));
+  }
+}
+
+/**
+ * expo-notifications includes a BOOT_COMPLETED receiver for restoring/rescheduling notifications after reboot.
+ * OrkaChat uses push notifications only (no scheduled/local notifications), so we remove boot handling to avoid
+ * Android 15+ BOOT_COMPLETED foreground-service restrictions warnings.
+ */
+module.exports = function withNoBootCompletedNotifications(config) {
+  return withAndroidManifest(config, (config) => {
+    const manifest = config.modResults;
+
+    removeUsesPermission(manifest, 'android.permission.RECEIVE_BOOT_COMPLETED');
+    removeBootActionsFromNotificationsReceiver(manifest);
+
+    config.modResults = manifest;
+    return config;
+  });
+};
+

--- a/frontend/plugins/withNoMlkitCodeScanner.js
+++ b/frontend/plugins/withNoMlkitCodeScanner.js
@@ -1,0 +1,50 @@
+const { withAndroidManifest } = require('@expo/config-plugins');
+
+const MLKIT_META_NAME = 'com.google.mlkit.vision.DEPENDENCIES';
+const MLKIT_META_BARCODE_UI = 'barcode_ui';
+const MLKIT_CODE_SCANNER_ACTIVITY =
+  'com.google.mlkit.vision.codescanner.internal.GmsBarcodeScanningDelegateActivity';
+
+function removeApplicationMetaData(manifest, predicate) {
+  const app = manifest?.manifest?.application?.[0];
+  if (!app) return;
+  const md = app['meta-data'];
+  if (!Array.isArray(md)) return;
+  app['meta-data'] = md.filter((m) => !predicate(m));
+}
+
+function removeActivity(manifest, activityName) {
+  const app = manifest?.manifest?.application?.[0];
+  if (!app) return;
+  const acts = app.activity;
+  if (!Array.isArray(acts)) return;
+  app.activity = acts.filter((a) => a?.$?.['android:name'] !== activityName);
+}
+
+/**
+ * OrkaChat does not use barcode scanning. `expo-camera` declares the ML Kit barcode UI dependency
+ * which pulls in a portrait-locked activity flagged by Play Console for large-screen UX.
+ *
+ * This plugin removes:
+ * - com.google.mlkit.vision.DEPENDENCIES=barcode_ui (declared by expo-camera)
+ * - the ML Kit code-scanner delegate activity (portrait-locked)
+ *
+ * Camera photo/video capture for attachments is unaffected; barcode scanning will be disabled.
+ */
+module.exports = function withNoMlkitCodeScanner(config) {
+  return withAndroidManifest(config, (config) => {
+    const manifest = config.modResults;
+
+    removeApplicationMetaData(manifest, (m) => {
+      const name = m?.$?.['android:name'];
+      const value = m?.$?.['android:value'];
+      return name === MLKIT_META_NAME && String(value || '').trim() === MLKIT_META_BARCODE_UI;
+    });
+
+    removeActivity(manifest, MLKIT_CODE_SCANNER_ACTIVITY);
+
+    config.modResults = manifest;
+    return config;
+  });
+};
+

--- a/frontend/plugins/withNoMlkitCodeScanner.js
+++ b/frontend/plugins/withNoMlkitCodeScanner.js
@@ -47,4 +47,3 @@ module.exports = function withNoMlkitCodeScanner(config) {
     return config;
   });
 };
-

--- a/tools/manifest.xml
+++ b/tools/manifest.xml
@@ -1,0 +1,435 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:compileSdkVersion="36" android:compileSdkVersionCodename="16" android:versionCode="11" android:versionName="1.0.0" package="com.projxon.orkachat" platformBuildVersionCode="36" platformBuildVersionName="16">
+      
+  <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="36"/>
+      
+  <uses-permission android:name="android.permission.CAMERA"/>
+      
+  <uses-permission android:name="android.permission.INTERNET"/>
+      
+  <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
+      
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+      
+  <uses-permission android:name="android.permission.READ_MEDIA_AUDIO"/>
+      
+  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
+      
+  <uses-permission android:name="android.permission.READ_MEDIA_VIDEO"/>
+      
+  <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED"/>
+      
+  <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+      
+  <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+      
+  <uses-permission android:name="android.permission.VIBRATE"/>
+      
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+      
+  <queries>
+            
+    <intent>
+                  
+      <action android:name="android.intent.action.VIEW"/>
+                  
+      <category android:name="android.intent.category.BROWSABLE"/>
+                  
+      <data android:scheme="https"/>
+              
+    </intent>
+            
+        
+    <intent>
+                  
+      <action android:name="android.intent.action.OPEN_DOCUMENT"/>
+                  
+      <category android:name="android.intent.category.DEFAULT"/>
+                  
+      <category android:name="android.intent.category.OPENABLE"/>
+                  
+      <data android:mimeType="*/*"/>
+              
+    </intent>
+     
+        
+    <intent>
+                  
+      <action android:name="android.intent.action.OPEN_DOCUMENT_TREE"/>
+              
+    </intent>
+            
+    <intent>
+                  
+            
+      <action android:name="android.media.action.IMAGE_CAPTURE"/>
+              
+    </intent>
+            
+    <intent>
+                  
+            
+      <action android:name="android.media.action.ACTION_VIDEO_CAPTURE"/>
+              
+    </intent>
+            
+    <intent>
+                  
+            
+      <action android:name="android.intent.action.SEND"/>
+                  
+      <data android:mimeType="*/*"/>
+              
+    </intent>
+            
+    <intent>
+                  
+      <action android:name="androidx.camera.extensions.action.VENDOR_ACTION"/>
+              
+    </intent>
+            
+    <intent>
+                  
+      <action android:name="android.intent.action.GET_CONTENT"/>
+                  
+      <category android:name="android.intent.category.OPENABLE"/>
+                  
+      <data android:mimeType="*/*"/>
+              
+    </intent>
+        
+  </queries>
+      
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+      
+  <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
+      
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+      
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
+      
+  <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+      
+  <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+      
+  <uses-permission android:name="android.permission.WAKE_LOCK"/>
+   
+    
+  <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE"/>
+      
+  <uses-permission android:name="android.permission.USE_BIOMETRIC"/>
+   
+    
+  <uses-permission android:name="android.permission.USE_FINGERPRINT"/>
+      
+  <permission android:name="com.projxon.orkachat.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION" android:protectionLevel="0x00000002"/>
+      
+  <uses-permission android:name="com.projxon.orkachat.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION"/>
+      
+  <uses-permission android:name="com.google.android.finsky.permission.BIND_GET_INSTALL_REFERRER_SERVICE"/>
+   
+    
+    
+    
+    
+    
+    
+  <uses-permission android:name="com.sec.android.provider.badge.permission.READ"/>
+      
+  <uses-permission android:name="com.sec.android.provider.badge.permission.WRITE"/>
+   
+    
+  <uses-permission android:name="com.htc.launcher.permission.READ_SETTINGS"/>
+      
+  <uses-permission android:name="com.htc.launcher.permission.UPDATE_SHORTCUT"/>
+   
+    
+  <uses-permission android:name="com.sonyericsson.home.permission.BROADCAST_BADGE"/>
+      
+  <uses-permission android:name="com.sonymobile.home.permission.PROVIDER_INSERT_BADGE"/>
+   
+    
+  <uses-permission android:name="com.anddoes.launcher.permission.UPDATE_COUNT"/>
+   
+    
+  <uses-permission android:name="com.majeur.launcher.permission.UPDATE_BADGE"/>
+   
+    
+  <uses-permission android:name="com.huawei.android.launcher.permission.CHANGE_BADGE"/>
+      
+  <uses-permission android:name="com.huawei.android.launcher.permission.READ_SETTINGS"/>
+      
+  <uses-permission android:name="com.huawei.android.launcher.permission.WRITE_SETTINGS"/>
+   
+    
+  <uses-permission android:name="android.permission.READ_APP_BADGE"/>
+   
+    
+  <uses-permission android:name="com.oppo.launcher.permission.READ_SETTINGS"/>
+      
+  <uses-permission android:name="com.oppo.launcher.permission.WRITE_SETTINGS"/>
+   
+    
+  <uses-permission android:name="me.everything.badger.permission.BADGE_COUNT_READ"/>
+      
+  <uses-permission android:name="me.everything.badger.permission.BADGE_COUNT_WRITE"/>
+      
+  <application android:allowBackup="true" android:appComponentFactory="androidx.core.app.CoreComponentFactory" android:dataExtractionRules="@xml/secure_store_data_extraction_rules" android:enableOnBackInvokedCallback="false" android:extractNativeLibs="false" android:fullBackupContent="@xml/secure_store_backup_rules" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:name="com.projxon.orkachat.MainApplication" android:requestLegacyExternalStorage="true" android:roundIcon="@mipmap/ic_launcher_round" android:supportsRtl="true" android:theme="@style/AppTheme">
+            
+    <meta-data android:name="com.google.firebase.messaging.default_notification_icon" android:resource="@drawable/notification_icon"/>
+            
+    <meta-data android:name="expo.modules.notifications.default_notification_icon" android:resource="@drawable/notification_icon"/>
+            
+    <meta-data android:name="expo.modules.updates.ENABLED" android:value="false"/>
+            
+    <meta-data android:name="expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH" android:value="ALWAYS"/>
+            
+    <meta-data android:name="expo.modules.updates.EXPO_UPDATES_LAUNCH_WAIT_MS" android:value="0"/>
+            
+    <activity android:configChanges="0x000007b0" android:exported="true" android:launchMode="2" android:name="com.projxon.orkachat.MainActivity" android:screenOrientation="-1" android:theme="@style/Theme.App.SplashScreen" android:windowSoftInputMode="0x00000010">
+                  
+      <intent-filter>
+                        
+        <action android:name="android.intent.action.MAIN"/>
+                        
+        <category android:name="android.intent.category.LAUNCHER"/>
+                    
+      </intent-filter>
+                  
+      <intent-filter>
+                        
+        <action android:name="android.intent.action.VIEW"/>
+                        
+        <category android:name="android.intent.category.DEFAULT"/>
+                        
+        <category android:name="android.intent.category.BROWSABLE"/>
+                        
+        <data android:scheme="exp+orkachat"/>
+                    
+      </intent-filter>
+              
+    </activity>
+            
+    <meta-data android:name="com.google.mlkit.vision.DEPENDENCIES" android:value="barcode_ui"/>
+            
+    <meta-data android:name="org.unimodules.core.AppLoader#react-native-headless" android:value="expo.modules.adapters.react.apploader.RNHeadlessAppLoader"/>
+            
+    <meta-data android:name="com.facebook.soloader.enabled" android:value="true"/>
+            
+    <activity android:configChanges="0x00000dc0" android:name="expo.modules.video.FullscreenPlayerActivity" android:supportsPictureInPicture="true" android:theme="@style/Fullscreen"/>
+            
+    <service android:exported="false" android:foregroundServiceType="0x00000002" android:name="expo.modules.audio.service.AudioControlsService">
+                  
+      <intent-filter>
+                        
+        <action android:name="androidx.media3.session.MediaSessionService"/>
+                    
+      </intent-filter>
+              
+    </service>
+            
+    <service android:exported="false" android:foregroundServiceType="0x00000080" android:name="expo.modules.audio.service.AudioRecordingService"/>
+            
+    <provider android:authorities="com.projxon.orkachat.ClipboardFileProvider" android:exported="true" android:name="expo.modules.clipboard.ClipboardFileProvider">
+                  
+      <meta-data android:name="expo.modules.clipboard.CLIPBOARD_FILE_PROVIDER_PATHS" android:resource="@xml/clipboard_provider_paths"/>
+              
+    </provider>
+            
+    <provider android:authorities="com.projxon.orkachat.FileSystemFileProvider" android:exported="false" android:grantUriPermissions="true" android:name="expo.modules.filesystem.FileSystemFileProvider">
+                  
+      <meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/file_system_provider_paths"/>
+              
+    </provider>
+            
+    <service android:enabled="false" android:exported="false" android:name="com.google.android.gms.metadata.ModuleDependencies">
+                  
+      <intent-filter>
+                        
+        <action android:name="com.google.android.gms.metadata.MODULE_DEPENDENCIES"/>
+                    
+      </intent-filter>
+                  
+      <meta-data android:name="photopicker_activity:0:required" android:value=""/>
+              
+    </service>
+            
+    <activity android:exported="false" android:name="expo.modules.imagepicker.ExpoCropImageActivity" android:theme="@style/Base.Theme.AppCompat"/>
+     
+        
+    <provider android:authorities="com.projxon.orkachat.ImagePickerFileProvider" android:exported="false" android:grantUriPermissions="true" android:name="expo.modules.imagepicker.fileprovider.ImagePickerFileProvider">
+                  
+      <meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/image_picker_provider_paths"/>
+              
+    </provider>
+            
+    <service android:exported="false" android:name="expo.modules.notifications.service.ExpoFirebaseMessagingService">
+                  
+      <intent-filter android:priority="-1">
+                        
+        <action android:name="com.google.firebase.MESSAGING_EVENT"/>
+                    
+      </intent-filter>
+              
+    </service>
+            
+    <receiver android:enabled="true" android:exported="false" android:name="expo.modules.notifications.service.NotificationsService">
+                  
+      <intent-filter android:priority="-1">
+                        
+        <action android:name="expo.modules.notifications.NOTIFICATION_EVENT"/>
+                        
+        <action android:name="android.intent.action.BOOT_COMPLETED"/>
+                        
+        <action android:name="android.intent.action.REBOOT"/>
+                        
+        <action android:name="android.intent.action.QUICKBOOT_POWERON"/>
+                        
+        <action android:name="com.htc.intent.action.QUICKBOOT_POWERON"/>
+                        
+        <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
+                    
+      </intent-filter>
+              
+    </receiver>
+            
+    <activity android:excludeFromRecents="true" android:exported="false" android:launchMode="0" android:name="expo.modules.notifications.service.NotificationForwarderActivity" android:noHistory="true" android:taskAffinity="" android:theme="@android:style/Theme.Translucent.NoTitleBar"/>
+            
+    <provider android:authorities="com.projxon.orkachat.SharingFileProvider" android:exported="false" android:grantUriPermissions="true" android:name="expo.modules.sharing.SharingFileProvider">
+                  
+      <meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/sharing_provider_paths"/>
+              
+    </provider>
+            
+    <receiver android:exported="true" android:name="com.google.firebase.iid.FirebaseInstanceIdReceiver" android:permission="com.google.android.c2dm.permission.SEND">
+                  
+      <intent-filter>
+                        
+        <action android:name="com.google.android.c2dm.intent.RECEIVE"/>
+                    
+      </intent-filter>
+                  
+      <meta-data android:name="com.google.android.gms.cloudmessaging.FINISHED_AFTER_HANDLED" android:value="true"/>
+              
+    </receiver>
+            
+        
+    <service android:directBootAware="true" android:exported="false" android:name="com.google.firebase.messaging.FirebaseMessagingService">
+                  
+      <intent-filter android:priority="-500">
+                        
+        <action android:name="com.google.firebase.MESSAGING_EVENT"/>
+                    
+      </intent-filter>
+              
+    </service>
+            
+    <service android:directBootAware="true" android:exported="false" android:name="com.google.firebase.components.ComponentDiscoveryService">
+                  
+      <meta-data android:name="com.google.firebase.components:com.google.firebase.messaging.FirebaseMessagingKtxRegistrar" android:value="com.google.firebase.components.ComponentRegistrar"/>
+                  
+      <meta-data android:name="com.google.firebase.components:com.google.firebase.messaging.FirebaseMessagingRegistrar" android:value="com.google.firebase.components.ComponentRegistrar"/>
+                  
+      <meta-data android:name="com.google.firebase.components:com.google.firebase.installations.FirebaseInstallationsKtxRegistrar" android:value="com.google.firebase.components.ComponentRegistrar"/>
+                  
+      <meta-data android:name="com.google.firebase.components:com.google.firebase.installations.FirebaseInstallationsRegistrar" android:value="com.google.firebase.components.ComponentRegistrar"/>
+                  
+      <meta-data android:name="com.google.firebase.components:com.google.firebase.ktx.FirebaseCommonLegacyRegistrar" android:value="com.google.firebase.components.ComponentRegistrar"/>
+                  
+      <meta-data android:name="com.google.firebase.components:com.google.firebase.FirebaseCommonKtxRegistrar" android:value="com.google.firebase.components.ComponentRegistrar"/>
+                  
+      <meta-data android:name="com.google.firebase.components:com.google.firebase.datatransport.TransportRegistrar" android:value="com.google.firebase.components.ComponentRegistrar"/>
+              
+    </service>
+            
+        
+    <activity android:exported="false" android:name="com.google.mlkit.vision.codescanner.internal.GmsBarcodeScanningDelegateActivity" android:screenOrientation="1">
+        </activity>
+            
+    <uses-library android:name="androidx.camera.extensions.impl" android:required="false"/>
+            
+    <service android:enabled="false" android:exported="false" android:name="androidx.camera.core.impl.MetadataHolderService">
+                  
+      <meta-data android:name="androidx.camera.core.impl.MetadataHolderService.DEFAULT_CONFIG_PROVIDER" android:value="androidx.camera.camera2.Camera2Config$DefaultProvider"/>
+              
+    </service>
+            
+    <provider android:authorities="com.projxon.orkachat.cropper.fileprovider" android:exported="false" android:grantUriPermissions="true" android:name="com.canhub.cropper.CropFileProvider">
+                  
+      <meta-data android:name="android.support.FILE_PROVIDER_PATHS" android:resource="@xml/library_file_paths"/>
+              
+    </provider>
+            
+    <activity android:exported="true" android:name="com.canhub.cropper.CropImageActivity"/>
+            
+    <service android:directBootAware="true" android:exported="false" android:name="com.google.mlkit.common.internal.MlKitComponentDiscoveryService">
+                  
+      <meta-data android:name="com.google.firebase.components:com.google.mlkit.vision.barcode.internal.BarcodeRegistrar" android:value="com.google.firebase.components.ComponentRegistrar"/>
+                  
+      <meta-data android:name="com.google.firebase.components:com.google.mlkit.vision.common.internal.VisionCommonRegistrar" android:value="com.google.firebase.components.ComponentRegistrar"/>
+                  
+      <meta-data android:name="com.google.firebase.components:com.google.mlkit.common.internal.CommonComponentRegistrar" android:value="com.google.firebase.components.ComponentRegistrar"/>
+              
+    </service>
+            
+    <provider android:authorities="com.projxon.orkachat.mlkitinitprovider" android:exported="false" android:initOrder="99" android:name="com.google.mlkit.common.internal.MlKitInitProvider"/>
+            
+    <provider android:authorities="com.projxon.orkachat.firebaseinitprovider" android:directBootAware="true" android:exported="false" android:initOrder="100" android:name="com.google.firebase.provider.FirebaseInitProvider"/>
+            
+    <activity android:exported="false" android:name="com.google.android.gms.common.api.GoogleApiActivity" android:theme="@android:style/Theme.Translucent.NoTitleBar"/>
+            
+    <provider android:authorities="com.projxon.orkachat.androidx-startup" android:exported="false" android:name="androidx.startup.InitializationProvider">
+                  
+      <meta-data android:name="androidx.emoji2.text.EmojiCompatInitializer" android:value="androidx.startup"/>
+                  
+      <meta-data android:name="androidx.lifecycle.ProcessLifecycleInitializer" android:value="androidx.startup"/>
+                  
+      <meta-data android:name="androidx.profileinstaller.ProfileInstallerInitializer" android:value="androidx.startup"/>
+              
+    </provider>
+            
+    <meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version"/>
+            
+    <activity android:exported="true" android:name="androidx.compose.ui.tooling.PreviewActivity"/>
+            
+    <receiver android:directBootAware="false" android:enabled="true" android:exported="true" android:name="androidx.profileinstaller.ProfileInstallReceiver" android:permission="android.permission.DUMP">
+                  
+      <intent-filter>
+                        
+        <action android:name="androidx.profileinstaller.action.INSTALL_PROFILE"/>
+                    
+      </intent-filter>
+                  
+      <intent-filter>
+                        
+        <action android:name="androidx.profileinstaller.action.SKIP_FILE"/>
+                    
+      </intent-filter>
+                  
+      <intent-filter>
+                        
+        <action android:name="androidx.profileinstaller.action.SAVE_PROFILE"/>
+                    
+      </intent-filter>
+                  
+      <intent-filter>
+                        
+        <action android:name="androidx.profileinstaller.action.BENCHMARK_OPERATION"/>
+                    
+      </intent-filter>
+              
+    </receiver>
+            
+    <service android:exported="false" android:name="com.google.android.datatransport.runtime.backends.TransportBackendDiscovery">
+                  
+      <meta-data android:name="backend:com.google.android.datatransport.cct.CctBackendFactory" android:value="cct"/>
+              
+    </service>
+            
+    <service android:exported="false" android:name="com.google.android.datatransport.runtime.scheduling.jobscheduling.JobInfoSchedulerService" android:permission="android.permission.BIND_JOB_SERVICE">
+        </service>
+            
+    <receiver android:exported="false" android:name="com.google.android.datatransport.runtime.scheduling.jobscheduling.AlarmManagerSchedulerBroadcastReceiver"/>
+        
+  </application>
+  
+</manifest>


### PR DESCRIPTION
Fixed these google play warnings: 

> Needs attention
> Restricted foreground service types
> Your app currently starts restricted foreground service types using BOOT_COMPLETED broadcast receivers in certain places. Apps targeting Android 15 or later will not be able to use BOOT_COMPLETED broadcast receivers to launch certain foreground service types, and doing this will cause your app to crash for users on Android 15 and later.

These was due to push notifications. Applied a change to remove this, hopefully push notifications still work if user reboots their phone

> Your app uses deprecated APIs or parameters for edge-to-edge
> One or more of the APIs you use or parameters that you set for edge-to-edge and window display have been deprecated in Android 15. To fix this, migrate away from these APIs or parameters.

This is a react native and expo issue. Will have to wait for them to update.

> Remove resizability and orientation restrictions in your app to support large screen devices
> From Android 16, Android will ignore resizability and orientation restrictions for large screen devices, such as foldables and tablets. This may lead to layout and usability issues for your users.

This was due to a bar code scanner. Our app does not use a bar code scanner, but it is included in the package for using the camera to take pictures to attach from the app for messages.