### PR TITLE
Proper Enter behavior on web, web mobile, and mobile

### DIFF
--- a/frontend/src/features/chat/useChatSendActions.ts
+++ b/frontend/src/features/chat/useChatSendActions.ts
@@ -26,7 +26,7 @@ export type ReplyTarget = {
   mediaFileName?: string;
 };
 
-type TextInputLike = { clear?: () => void };
+type TextInputLike = { clear?: () => void; focus?: () => void; blur?: () => void };
 
 function getErrorMessage(err: unknown): string {
   if (err instanceof Error) return err.message || 'Unknown error';
@@ -307,9 +307,8 @@ export function useChatSendActions(opts: {
         : null;
 
     const clearDraftImmediately = () => {
-      // Force-remount the TextInput to fully reset native state.
-      // This is the most reliable way to guarantee "instant clear" on Android
-      // even if the user keeps typing and spams Send.
+      // Bump epoch to reset composer layout state (eg. height).
+      // Note: the TextInput itself is kept stable (no remount) to avoid keyboard glitches.
       setInputEpoch((v) => v + 1);
       try {
         textInputRef.current?.clear?.();


### PR DESCRIPTION
Proper Enter and Send behavior allowing for more streamlined and faster send and text entry behavior without having to focus again into chat composer

On Web - Enter sends message, keeps input focused. Shift + enter is newline. If web user adds attachment or adds voice clip, focus is kept in text input, even if they cancel or close the process.

On Mobile - Enter is newline, Send keeps text input focused and mobile keyboard still stays up if it is up. 

Smooth if user hits send after having swiped their keyboard away - Input it still focused by keyboard does not pop back up after hitting send. Adding attachment, and holding or pressing voice clip does not interfere.

On Mobile Web - Enter is newline, send keeps text input focused and mobile keyboard still stays up if it is up. If keyboard is not present when hitting send, text input is unfocused. If voice clip is held or attachment is added keyboard will go away though, can't fix that, and focus exits text input.

Camera on web shifts close to top right then top left.

Address camera and preview flipping on mobile, web, mobile web. Web cameras may mirror images, so Mirror Image option added.