### PR TITLE
Enter is submit on all forms, AppTextInput component test

### DIFF
--- a/frontend/src/components/__tests__/AppBrandIcon.test.tsx
+++ b/frontend/src/components/__tests__/AppBrandIcon.test.tsx
@@ -1,0 +1,78 @@
+import { render } from '@testing-library/react-native';
+import * as React from 'react';
+import { Image, StyleSheet } from 'react-native';
+
+import { AppBrandIcon } from '../AppBrandIcon';
+
+function getImage(screen: ReturnType<typeof render>) {
+  return screen.UNSAFE_getByType(Image);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('AppBrandIcon', () => {
+  test('defaults to accessible, clipped, rounded slot with label', () => {
+    const screen = render(<AppBrandIcon isDark={false} />);
+
+    const slot = screen.getByLabelText('App icon');
+    const slotStyle = StyleSheet.flatten(slot.props.style);
+
+    expect(slot.props.accessible).toBe(true);
+    expect(slot.props.accessibilityLabel).toBe('App icon');
+
+    // Defaults: clipped + rounded
+    expect(slotStyle.overflow).toBe('hidden');
+    expect(slotStyle.borderRadius).toBe(999);
+  });
+
+  test('fit="crop" uses resizeMode="cover" and zoom/zoomLight/zoomDark rules', () => {
+    const screenLight = render(<AppBrandIcon isDark={false} fit="crop" />);
+    const imgLight = getImage(screenLight);
+    const imgLightStyle = StyleSheet.flatten(imgLight.props.style);
+
+    expect(imgLight.props.resizeMode).toBe('cover');
+    expect(imgLightStyle.transform?.[0]?.scale).toBeCloseTo(2.15, 5);
+
+    const screenDark = render(<AppBrandIcon isDark fit="crop" />);
+    const imgDark = getImage(screenDark);
+    const imgDarkStyle = StyleSheet.flatten(imgDark.props.style);
+
+    expect(imgDark.props.resizeMode).toBe('cover');
+    expect(imgDarkStyle.transform?.[0]?.scale).toBeCloseTo(2.45, 5);
+
+    // The require(...) sources should differ between light/dark
+    expect(imgLight.props.source).not.toEqual(imgDark.props.source);
+
+    // Explicit zoom overrides the defaults
+    const screenOverride = render(<AppBrandIcon isDark fit="crop" zoom={3} />);
+    const imgOverride = getImage(screenOverride);
+    const imgOverrideStyle = StyleSheet.flatten(imgOverride.props.style);
+
+    expect(imgOverrideStyle.transform?.[0]?.scale).toBe(3);
+  });
+
+  test('fit="contain" uses resizeMode="contain" and containZoom rules', () => {
+    const screenLight = render(<AppBrandIcon isDark={false} fit="contain" />);
+    const imgLight = getImage(screenLight);
+    const imgLightStyle = StyleSheet.flatten(imgLight.props.style);
+
+    expect(imgLight.props.resizeMode).toBe('contain');
+    expect(imgLightStyle.transform?.[0]?.scale).toBeCloseTo(1.7, 5);
+
+    const screenDark = render(<AppBrandIcon isDark fit="contain" />);
+    const imgDark = getImage(screenDark);
+    const imgDarkStyle = StyleSheet.flatten(imgDark.props.style);
+
+    expect(imgDark.props.resizeMode).toBe('contain');
+    expect(imgDarkStyle.transform?.[0]?.scale).toBeCloseTo(1.25, 5);
+
+    // containZoom=1 disables the extra transform
+    const screenNoZoom = render(<AppBrandIcon isDark={false} fit="contain" containZoom={1} />);
+    const imgNoZoom = getImage(screenNoZoom);
+    const imgNoZoomStyle = StyleSheet.flatten(imgNoZoom.props.style);
+
+    expect(imgNoZoomStyle.transform).toBeUndefined();
+  });
+});

--- a/frontend/src/components/__tests__/AppTextInput.test.tsx
+++ b/frontend/src/components/__tests__/AppTextInput.test.tsx
@@ -1,0 +1,242 @@
+import { fireEvent, render } from '@testing-library/react-native';
+import * as React from 'react';
+import { StyleSheet } from 'react-native';
+
+import { APP_COLORS, PALETTE } from '../../theme/colors';
+
+type PlatformOS = 'ios' | 'web';
+
+function loadAppTextInputForPlatform(os: PlatformOS) {
+  jest.resetModules();
+
+  // Mock react-native *before* importing the component so Platform.OS branches
+  // are evaluated correctly at module load time.
+  jest.doMock('react-native', () => {
+    const RN = jest.requireActual('react-native');
+    return {
+      ...RN,
+      Platform: { ...RN.Platform, OS: os },
+    };
+  });
+
+  let AppTextInput: unknown;
+
+  jest.isolateModules(() => {
+    AppTextInput = require('../AppTextInput').AppTextInput;
+  });
+
+  return { AppTextInput: AppTextInput as React.ComponentType<any> };
+}
+
+function getInput(screen: ReturnType<typeof render>, testID = 'input') {
+  return screen.getByTestId(testID);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('AppTextInput (native branch)', () => {
+  test('defaults placeholder/selection/cursor colors for light mode', () => {
+    const { AppTextInput } = loadAppTextInputForPlatform('ios');
+
+    const screen = render(
+      <AppTextInput testID="input" isDark={false} value="" onChangeText={() => {}} />,
+    );
+
+    const input = getInput(screen);
+
+    expect(input.props.placeholderTextColor).toBe(PALETTE.slate350);
+    expect(input.props.selectionColor).toBe(APP_COLORS.light.text.primary);
+    expect(input.props.cursorColor).toBe(APP_COLORS.light.text.primary);
+  });
+
+  test('defaults placeholder/selection/cursor colors for dark mode', () => {
+    const { AppTextInput } = loadAppTextInputForPlatform('ios');
+
+    const screen = render(<AppTextInput testID="input" isDark value="" onChangeText={() => {}} />);
+
+    const input = getInput(screen);
+
+    expect(input.props.placeholderTextColor).toBe(PALETTE.slate400);
+    expect(input.props.selectionColor).toBe(APP_COLORS.dark.text.primary);
+    expect(input.props.cursorColor).toBe(APP_COLORS.dark.text.primary);
+  });
+
+  test('respects explicit color overrides', () => {
+    const { AppTextInput } = loadAppTextInputForPlatform('ios');
+
+    const screen = render(
+      <AppTextInput
+        testID="input"
+        isDark={false}
+        value=""
+        onChangeText={() => {}}
+        placeholderTextColor="hotpink"
+        selectionColor="gold"
+        cursorColor="cyan"
+      />,
+    );
+
+    const input = getInput(screen);
+
+    expect(input.props.placeholderTextColor).toBe('hotpink');
+    expect(input.props.selectionColor).toBe('gold');
+    expect(input.props.cursorColor).toBe('cyan');
+  });
+
+  test('composes baseStyle + darkStyle and supports blocksStandalone variant', () => {
+    const { AppTextInput } = loadAppTextInputForPlatform('ios');
+
+    const baseStyle = { backgroundColor: 'red', borderWidth: 1 };
+    const darkStyle = { backgroundColor: 'black' };
+
+    const screen = render(
+      <AppTextInput
+        testID="input"
+        isDark
+        value=""
+        onChangeText={() => {}}
+        baseStyle={baseStyle}
+        darkStyle={darkStyle}
+        variant="blocksStandalone"
+      />,
+    );
+
+    const input = getInput(screen);
+    const flattened = StyleSheet.flatten(input.props.style);
+
+    // darkStyle should override baseStyle when isDark is true
+    expect(flattened.backgroundColor).toBe('black');
+    // blocksStandalone variant contributes stable sizing/layout fields
+    expect(flattened.height).toBe(44);
+    expect(flattened.width).toBe('100%');
+  });
+
+  test('calls onFocus/onBlur and toggles focus style (native uses elevation)', () => {
+    const { AppTextInput } = loadAppTextInputForPlatform('ios');
+
+    const onFocus = jest.fn();
+    const onBlur = jest.fn();
+
+    const screen = render(
+      <AppTextInput
+        testID="input"
+        isDark={false}
+        value=""
+        onChangeText={() => {}}
+        onFocus={onFocus}
+        onBlur={onBlur}
+      />,
+    );
+
+    const input = getInput(screen);
+
+    // Not focused initially
+    expect(StyleSheet.flatten(input.props.style).elevation).toBeUndefined();
+
+    fireEvent(input, 'focus');
+    expect(onFocus).toHaveBeenCalledTimes(1);
+    expect(StyleSheet.flatten(getInput(screen).props.style).elevation).toBe(2);
+
+    fireEvent(getInput(screen), 'blur');
+    expect(onBlur).toHaveBeenCalledTimes(1);
+    expect(StyleSheet.flatten(getInput(screen).props.style).elevation).toBeUndefined();
+  });
+});
+
+describe('AppTextInput (web branch)', () => {
+  test('Enter (no shift) calls onSubmitEditing and prevents default', () => {
+    const { AppTextInput } = loadAppTextInputForPlatform('web');
+
+    const onKeyPress = jest.fn();
+    const onSubmitEditing = jest.fn();
+    const preventDefault = jest.fn();
+    const stopPropagation = jest.fn();
+
+    const screen = render(
+      <AppTextInput
+        testID="input"
+        isDark={false}
+        value=""
+        onChangeText={() => {}}
+        onKeyPress={onKeyPress}
+        onSubmitEditing={onSubmitEditing}
+      />,
+    );
+
+    const input = getInput(screen);
+
+    fireEvent(input, 'keyPress', {
+      nativeEvent: { key: 'Enter', shiftKey: false },
+      preventDefault,
+      stopPropagation,
+    });
+
+    expect(onKeyPress).toHaveBeenCalledTimes(1);
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(stopPropagation).toHaveBeenCalledTimes(1);
+    expect(onSubmitEditing).toHaveBeenCalledTimes(1);
+  });
+
+  test('Shift+Enter does not submit', () => {
+    const { AppTextInput } = loadAppTextInputForPlatform('web');
+
+    const onSubmitEditing = jest.fn();
+    const preventDefault = jest.fn();
+    const stopPropagation = jest.fn();
+
+    const screen = render(
+      <AppTextInput
+        testID="input"
+        isDark={false}
+        value=""
+        onChangeText={() => {}}
+        onSubmitEditing={onSubmitEditing}
+      />,
+    );
+
+    fireEvent(getInput(screen), 'keyPress', {
+      nativeEvent: { key: 'Enter', shiftKey: true },
+      preventDefault,
+      stopPropagation,
+    });
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(stopPropagation).not.toHaveBeenCalled();
+    expect(onSubmitEditing).not.toHaveBeenCalled();
+  });
+
+  test('multiline inputs do not intercept Enter to submit', () => {
+    const { AppTextInput } = loadAppTextInputForPlatform('web');
+
+    const onKeyPress = jest.fn();
+    const onSubmitEditing = jest.fn();
+    const preventDefault = jest.fn();
+    const stopPropagation = jest.fn();
+
+    const screen = render(
+      <AppTextInput
+        testID="input"
+        isDark={false}
+        value=""
+        onChangeText={() => {}}
+        multiline
+        onKeyPress={onKeyPress}
+        onSubmitEditing={onSubmitEditing}
+      />,
+    );
+
+    fireEvent(getInput(screen), 'keyPress', {
+      nativeEvent: { key: 'Enter', shiftKey: false },
+      preventDefault,
+      stopPropagation,
+    });
+
+    // Still calls caller's onKeyPress, but should not route to submit in multiline mode.
+    expect(onKeyPress).toHaveBeenCalledTimes(1);
+    expect(onSubmitEditing).not.toHaveBeenCalled();
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(stopPropagation).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/__tests__/ThemeToggleRow.test.tsx
+++ b/frontend/src/components/__tests__/ThemeToggleRow.test.tsx
@@ -1,0 +1,84 @@
+import { fireEvent, render } from '@testing-library/react-native';
+import * as React from 'react';
+import { Platform, Switch } from 'react-native';
+
+import type { ThemeToggleRowStyles } from '../ThemeToggleRow';
+import { ThemeToggleRow } from '../ThemeToggleRow';
+
+jest.mock('@expo/vector-icons/Feather', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+
+  return function MockFeather(props: { name?: unknown }) {
+    return React.createElement(Text, { testID: 'feather-icon' }, String(props.name ?? ''));
+  };
+});
+
+type PlatformOS = 'ios' | 'web';
+
+function withPlatformOS<T>(os: PlatformOS, run: () => T): T {
+  const originalOS = Platform.OS;
+  Object.defineProperty(Platform, 'OS', { value: os, configurable: true });
+
+  try {
+    return run();
+  } finally {
+    Object.defineProperty(Platform, 'OS', { value: originalOS, configurable: true });
+  }
+}
+
+const styles: ThemeToggleRowStyles = {
+  themeToggle: {},
+  webToggleTrack: {},
+  webToggleThumb: {},
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('ThemeToggleRow (native branch)', () => {
+  test('renders a Switch and maps value changes to onSetTheme', () => {
+    withPlatformOS('ios', () => {
+      const onSetTheme = jest.fn();
+
+      const screen = render(
+        <ThemeToggleRow isDark={false} onSetTheme={onSetTheme} styles={styles} />,
+      );
+
+      const sw = screen.UNSAFE_getByType(Switch);
+      sw.props.onValueChange(true);
+
+      expect(onSetTheme).toHaveBeenCalledTimes(1);
+      expect(onSetTheme).toHaveBeenCalledWith('dark');
+    });
+  });
+
+  test('shows sun/moon icon based on isDark', () => {
+    withPlatformOS('ios', () => {
+      const screenLight = render(
+        <ThemeToggleRow isDark={false} onSetTheme={() => {}} styles={styles} />,
+      );
+      expect(screenLight.getByTestId('feather-icon').props.children).toBe('sun');
+
+      const screenDark = render(<ThemeToggleRow isDark onSetTheme={() => {}} styles={styles} />);
+      expect(screenDark.getByTestId('feather-icon').props.children).toBe('moon');
+    });
+  });
+});
+
+describe('ThemeToggleRow (web branch)', () => {
+  test('renders a button and toggles theme on press', () => {
+    withPlatformOS('web', () => {
+      const onSetTheme = jest.fn();
+
+      const screen = render(
+        <ThemeToggleRow isDark={false} onSetTheme={onSetTheme} styles={styles} />,
+      );
+      fireEvent.press(screen.getByLabelText('Toggle theme'));
+
+      expect(onSetTheme).toHaveBeenCalledTimes(1);
+      expect(onSetTheme).toHaveBeenCalledWith('dark');
+    });
+  });
+});

--- a/frontend/src/features/chat/components/ChannelMembersModal.tsx
+++ b/frontend/src/features/chat/components/ChannelMembersModal.tsx
@@ -67,6 +67,10 @@ export function ChannelMembersModal({
                 }}
                 value={addMembersDraft}
                 onChangeText={onChangeAddMembersDraft}
+                onSubmitEditing={() => {
+                  if (actionBusy) return;
+                  void Promise.resolve(onAddMembers());
+                }}
                 placeholder="Add usernames (comma/space separated)"
                 // Use explicit style (modal on Android can be finicky).
                 style={{

--- a/frontend/src/features/chat/components/GroupMembersModal.tsx
+++ b/frontend/src/features/chat/components/GroupMembersModal.tsx
@@ -106,6 +106,10 @@ export function GroupMembersModal({
                 }}
                 value={addMembersDraft}
                 onChangeText={onChangeAddMembersDraft}
+                onSubmitEditing={() => {
+                  if (busy) return;
+                  void Promise.resolve(onAddMembers());
+                }}
                 placeholder="Add usernames (comma/space separated)"
                 // Use a fully explicit style here (avoid theme/style collisions in Android modals).
                 style={{

--- a/frontend/src/features/chat/components/__tests__/ChatComposer.test.tsx
+++ b/frontend/src/features/chat/components/__tests__/ChatComposer.test.tsx
@@ -1,0 +1,239 @@
+import { fireEvent, render } from '@testing-library/react-native';
+import type { ComponentProps } from 'react';
+import * as React from 'react';
+import { Platform, TextInput } from 'react-native';
+
+import { ChatComposer } from '../ChatComposer';
+
+jest.mock('@expo/vector-icons', () => {
+  const React = require('react');
+  return {
+    MaterialIcons: function MockMaterialIcons() {
+      return React.createElement(React.Fragment, null);
+    },
+  };
+});
+
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => {
+  const React = require('react');
+  return function MockMaterialCommunityIcons() {
+    return React.createElement(React.Fragment, null);
+  };
+});
+
+jest.mock('../VoiceClipMicButton', () => {
+  const React = require('react');
+  return {
+    VoiceClipMicButton: function MockVoiceClipMicButton() {
+      return React.createElement(React.Fragment, null);
+    },
+  };
+});
+
+jest.mock('../../../../components/AnimatedDots', () => {
+  const React = require('react');
+  return {
+    AnimatedDots: function MockAnimatedDots() {
+      return React.createElement(React.Fragment, null);
+    },
+  };
+});
+
+type PlatformOS = 'ios' | 'web';
+
+function withPlatformOS<T>(os: PlatformOS, run: () => T): T {
+  const originalOS = Platform.OS;
+  Object.defineProperty(Platform, 'OS', { value: os, configurable: true });
+  try {
+    return run();
+  } finally {
+    Object.defineProperty(Platform, 'OS', { value: originalOS, configurable: true });
+  }
+}
+
+function withWindow<T>(w: Partial<Window> | undefined, run: () => T): T {
+  const g = globalThis as unknown as { window?: unknown };
+  const original = g.window;
+  if (typeof w === 'undefined') delete g.window;
+  else g.window = w as unknown as Window;
+
+  try {
+    return run();
+  } finally {
+    if (typeof original === 'undefined') delete g.window;
+    else g.window = original;
+  }
+}
+
+type Props = ComponentProps<typeof ChatComposer>;
+
+function makeProps(overrides: Partial<Props> = {}): Props {
+  return {
+    styles: {} as any,
+    isDark: false,
+    myUserId: 'me',
+    isDm: true,
+    isGroup: false,
+    isEncryptedChat: false,
+    groupMeta: null,
+
+    inlineEditTargetId: null,
+    inlineEditUploading: false,
+    cancelInlineEdit: () => {},
+
+    pendingMedia: [],
+    setPendingMedia: () => {},
+    isUploading: false,
+
+    replyTarget: null,
+    setReplyTarget: () => {},
+    messages: [],
+    openViewer: () => {},
+
+    typingIndicatorText: '',
+    TypingIndicator: () => null,
+    typingColor: '#000',
+
+    mentionSuggestions: [],
+    insertMention: () => {},
+
+    composerSafeAreaStyle: {},
+    composerHorizontalInsetsStyle: {},
+    composerBottomInsetBgHeight: 0,
+    androidKeyboardLift: 0,
+    isWideChatLayout: false,
+
+    textInputRef: { current: null } as { current: TextInput | null },
+    inputEpoch: 0,
+    input: '',
+    onChangeInput: () => {},
+    isTypingRef: { current: false } as { current: boolean },
+    sendTyping: () => {},
+    sendMessage: () => {},
+
+    handlePickMedia: () => {},
+    showAlert: () => {},
+    stopAudioPlayback: () => {},
+
+    ...overrides,
+  };
+}
+
+function getComposerInput(screen: ReturnType<typeof render>) {
+  return screen.UNSAFE_getByType(TextInput);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('ChatComposer (web Enter-to-send behavior)', () => {
+  test('desktop web: Enter (no shift) prevents default and calls sendMessage', () => {
+    withPlatformOS('web', () => {
+      withWindow(undefined, () => {
+        const sendMessage = jest.fn();
+        const preventDefault = jest.fn();
+        const stopPropagation = jest.fn();
+
+        const screen = render(<ChatComposer {...makeProps({ sendMessage })} />);
+        const input = getComposerInput(screen);
+
+        input.props.onKeyPress?.({
+          nativeEvent: { key: 'Enter', shiftKey: false },
+          preventDefault,
+          stopPropagation,
+        });
+
+        expect(preventDefault).toHaveBeenCalledTimes(1);
+        expect(stopPropagation).toHaveBeenCalledTimes(1);
+        expect(sendMessage).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  test('desktop web: Shift+Enter does not send', () => {
+    withPlatformOS('web', () => {
+      withWindow(undefined, () => {
+        const sendMessage = jest.fn();
+        const preventDefault = jest.fn();
+        const stopPropagation = jest.fn();
+
+        const screen = render(<ChatComposer {...makeProps({ sendMessage })} />);
+        const input = getComposerInput(screen);
+
+        input.props.onKeyPress?.({
+          nativeEvent: { key: 'Enter', shiftKey: true },
+          preventDefault,
+          stopPropagation,
+        });
+
+        expect(preventDefault).not.toHaveBeenCalled();
+        expect(stopPropagation).not.toHaveBeenCalled();
+        expect(sendMessage).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  test('desktop web: IME composing does not send', () => {
+    withPlatformOS('web', () => {
+      withWindow(undefined, () => {
+        const sendMessage = jest.fn();
+        const preventDefault = jest.fn();
+        const stopPropagation = jest.fn();
+
+        const screen = render(<ChatComposer {...makeProps({ sendMessage })} />);
+        const input = getComposerInput(screen);
+
+        input.props.onKeyPress?.({
+          nativeEvent: { key: 'Enter', shiftKey: false, isComposing: true },
+          preventDefault,
+          stopPropagation,
+        });
+
+        expect(preventDefault).not.toHaveBeenCalled();
+        expect(stopPropagation).not.toHaveBeenCalled();
+        expect(sendMessage).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  test('mobile web: Enter does not auto-send (users use Send button)', () => {
+    withPlatformOS('web', () => {
+      // Force isMobileWeb=true by providing a narrow window.
+      withWindow(
+        {
+          innerWidth: 375,
+          matchMedia: () => ({ matches: false }) as any,
+        },
+        () => {
+          const sendMessage = jest.fn();
+          const preventDefault = jest.fn();
+          const stopPropagation = jest.fn();
+
+          const screen = render(<ChatComposer {...makeProps({ sendMessage })} />);
+          const input = getComposerInput(screen);
+
+          input.props.onKeyPress?.({
+            nativeEvent: { key: 'Enter', shiftKey: false },
+            preventDefault,
+            stopPropagation,
+          });
+
+          expect(preventDefault).not.toHaveBeenCalled();
+          expect(stopPropagation).not.toHaveBeenCalled();
+          expect(sendMessage).not.toHaveBeenCalled();
+        },
+      );
+    });
+  });
+  test('native: pressing the Send button calls sendMessage', () => {
+    withPlatformOS('ios', () => {
+      const sendMessage = jest.fn();
+
+      const screen = render(<ChatComposer {...makeProps({ sendMessage })} />);
+      fireEvent.press(screen.getByText('Send'));
+
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/frontend/src/features/chat/useChatReport.ts
+++ b/frontend/src/features/chat/useChatReport.ts
@@ -169,7 +169,7 @@ export function useChatReport(opts: {
         const text = await resp.text().catch(() => '');
         throw new Error(text || `Report failed (${resp.status})`);
       }
-      setReportNotice({ type: 'success', message: 'Thanks - we’ll review this.' });
+      setReportNotice({ type: 'success', message: 'Thanks - we’ll review this' });
       // Give the user a moment to see the confirmation, then close.
       setTimeout(() => {
         setReportOpen(false);


### PR DESCRIPTION
Enter submits on Add Members for Channels and Group DMs. This standardizes Enter behavior across all fields as:

Single line inputs - Enter is submit web and mobile.

<details><summary>Exceptions:</summary>

- Editor requires Click on Save
- Cognito Auth forms require special behavior
- Changing passphrase on Enter Passphrase/Confirm Passphrase require form validation (enter works on 2nd line if form validated)
- Chat Composer (extra logic for new line, and focus/blur, and dismissing/restore keyboard on mobile and web mobile)
- Channel About (Enter is just new line since it's an editor basically, not frequently changed)
- Report (More sensitive form submission)
- AI Helper (Prevent accidental submissions, rate limiting)
- Start DM (submit is just called go)

</detals>

Jest Component Testing

ChatComposer has proper sendMessage behavior on web, web mobile, and mobile for Enter, and shift+enter

We have tests for proper AppBrandIcon styling behavior, ThemeToggle working, and AppTextInput for styling, focus/blur behavior, and web-only enter handling.




