### PR TITLE
Evan perry/apple debug begin

### DIFF
--- a/backend/aws/src/handlers/http/getUser.js
+++ b/backend/aws/src/handlers/http/getUser.js
@@ -64,10 +64,26 @@ exports.handler = async (event) => {
         Limit: 1,
       })
     );
-    const it = resp.Items?.[0];
-    if (!it) {
+    const gsiItem = resp.Items?.[0];
+    if (!gsiItem) {
       return { statusCode: 404, body: JSON.stringify({ message: 'User does not exist' }) };
     }
+
+    // GSI projection may omit `currentPublicKey` (and other attrs). Hydrate from base table by PK.
+    const subFromGsi = String(gsiItem.userSub || '').trim();
+    let it = gsiItem;
+    if (subFromGsi) {
+      try {
+        const full = await ddb.send(
+          new GetCommand({ TableName: usersTable, Key: { userSub: subFromGsi } }),
+        );
+        if (full.Item) it = full.Item;
+      } catch (e) {
+        console.error('getUser: hydrate after GSI failed', { subFromGsi, usernameLower }, e);
+        throw e;
+      }
+    }
+
     return {
       statusCode: 200,
       headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },

--- a/backend/aws/src/handlers/http/groupUpdate.js
+++ b/backend/aws/src/handlers/http/groupUpdate.js
@@ -82,15 +82,16 @@ async function getUserByUsernameLower(usersTable, usernameLower) {
   if (!item) return null;
 
   // IMPORTANT: DynamoDB GSI projection may not include `currentPublicKey`.
-  // Hydrate by PK to ensure we see full user attributes.
+  // Always hydrate by PK so we see full user attributes — otherwise we may return
+  // a partial GSI item and incorrectly reject users who do have keys.
   const sub = safeString(item.userSub);
   if (!sub) return item;
-  if (safeString(item.currentPublicKey)) return item;
   try {
     const full = await ddb.send(new GetCommand({ TableName: usersTable, Key: { userSub: sub } }));
-    return full.Item || item;
-  } catch {
-    return item;
+    return full.Item ?? item;
+  } catch (err) {
+    console.error('getUserByUsernameLower: hydrate failed', { sub, usernameLower: u }, err);
+    throw err;
   }
 }
 

--- a/backend/aws/src/handlers/http/startGroupDm.js
+++ b/backend/aws/src/handlers/http/startGroupDm.js
@@ -67,15 +67,16 @@ async function getUserByUsernameLower(usersTable, usernameLower) {
   if (!item) return null;
 
   // IMPORTANT: DynamoDB GSI projection may not include `currentPublicKey`.
-  // Hydrate by PK to ensure we see full user attributes.
+  // Always hydrate by PK so we see full user attributes — otherwise we may return
+  // a partial GSI item and incorrectly reject users who do have keys.
   const sub = safeString(item.userSub);
   if (!sub) return item;
-  if (safeString(item.currentPublicKey)) return item;
   try {
     const full = await getUserBySub(usersTable, sub);
-    return full || item;
-  } catch {
-    return item;
+    return full ?? item;
+  } catch (err) {
+    console.error('getUserByUsernameLower: hydrate failed', { sub, usernameLower: u }, err);
+    throw err;
   }
 }
 

--- a/frontend/App.styles.ts
+++ b/frontend/App.styles.ts
@@ -519,18 +519,27 @@ export const styles = StyleSheet.create({
   },
   modalInput: {
     height: 48,
-    // Keep explicit text metrics so modal inputs match other 48px controls.
     fontSize: 16,
-    lineHeight: 48,
-    paddingVertical: 0,
     paddingHorizontal: 12,
     borderWidth: 1,
     borderColor: PALETTE.lineDark,
     borderRadius: 10,
-    // Helps avoid descender clipping on Android.
-    includeFontPadding: false,
-    textAlignVertical: 'center',
     marginBottom: 12,
+    // Android / web: lineHeight === height centers single-line text in 48px fields.
+    // iOS: that pattern misaligns placeholder + secure entry (same as `blocksInput`).
+    ...Platform.select({
+      ios: {
+        paddingVertical: 13,
+        lineHeight: 20,
+      },
+      default: {
+        paddingVertical: 0,
+        lineHeight: 48,
+        // Helps avoid descender clipping on Android.
+        includeFontPadding: false,
+        textAlignVertical: 'center',
+      },
+    }),
   },
   passphraseFieldWrapper: {
     position: 'relative',
@@ -968,13 +977,23 @@ export const styles = StyleSheet.create({
     borderColor: APP_COLORS.light.border.subtle,
     backgroundColor: APP_COLORS.light.bg.surface2,
     paddingHorizontal: 12,
-    paddingVertical: 0,
     fontSize: 16,
-    lineHeight: 48,
-    // Helps avoid descender clipping on Android.
-    includeFontPadding: false,
-    textAlignVertical: 'center',
     color: APP_COLORS.light.text.primary,
+    // Android / web: single-line vertical centering via lineHeight === height.
+    // iOS: that pattern misaligns placeholder + typed text (placeholder looks “sunk”).
+    ...Platform.select({
+      ios: {
+        paddingVertical: 13,
+        lineHeight: 20,
+      },
+      default: {
+        paddingVertical: 0,
+        lineHeight: 48,
+        // Helps avoid descender clipping on Android.
+        includeFontPadding: false,
+        textAlignVertical: 'center',
+      },
+    }),
   },
   blocksInputDark: {
     backgroundColor: APP_COLORS.dark.bg.header,

--- a/frontend/App.styles.ts
+++ b/frontend/App.styles.ts
@@ -765,11 +765,21 @@ export const styles = StyleSheet.create({
   avatarTextColorBtnSelectedDark: { borderWidth: 2, borderColor: APP_COLORS.dark.text.primary },
   avatarTextColorLabel: { fontWeight: '800', color: APP_COLORS.light.text.primary },
   avatarTextColorLabelDark: { color: APP_COLORS.dark.text.primary },
-  profileActionsRow: { flexDirection: 'row', alignItems: 'center', gap: 10, marginTop: 12 },
+  // flexWrap + minWidth: lets long labels (e.g. "Choose Image") wrap to a second row on narrow
+  // modals (iOS width ~80%); without flexWrap, flex:1 children shrink and text clips.
+  profileActionsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'stretch',
+    gap: 10,
+    marginTop: 12,
+  },
   toolBtn: {
     flex: 1,
-    height: 40,
+    minWidth: 124,
+    minHeight: 40,
     paddingHorizontal: 12,
+    paddingVertical: 8,
     borderRadius: 12,
     backgroundColor: APP_COLORS.light.bg.surface2,
     borderWidth: StyleSheet.hairlineWidth,

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -33,10 +33,7 @@
       "softwareKeyboardLayoutMode": "resize",
       "package": "com.projxon.orkachat",
       "googleServicesFile": "./google-services.json",
-      "permissions": [
-        "android.permission.CAMERA",
-        "android.permission.RECORD_AUDIO"
-      ]
+      "permissions": ["android.permission.CAMERA", "android.permission.RECORD_AUDIO"]
     },
     "web": {
       "favicon": "./public/favicon-32.png"

--- a/frontend/src/components/HeaderMenuModal.tsx
+++ b/frontend/src/components/HeaderMenuModal.tsx
@@ -102,6 +102,147 @@ export function HeaderMenuModal({
     : 0;
   const maxCardH = Math.max(160, Math.floor(windowHeight - anchorTop - 12));
 
+  const cardContent = (
+    <>
+      <View style={styles.topRightCloseRow}>
+        {headerRight ? <View style={styles.headerRightSlot}>{headerRight}</View> : null}
+        <Pressable
+          onPress={onClose}
+          style={({ pressed }) => [
+            styles.closeIconBtn,
+            {
+              backgroundColor: btnBg,
+              borderColor: btnBorder,
+              borderWidth: btnBorderWidth,
+            },
+            pressed ? { opacity: 0.88 } : null,
+          ]}
+          accessibilityRole="button"
+          accessibilityLabel="Close menu"
+        >
+          <AppBrandIcon
+            isDark={isDark}
+            fit="contain"
+            slotWidth={32}
+            slotHeight={32}
+            accessible={false}
+          />
+        </Pressable>
+      </View>
+      {title ? (
+        <Text style={[styles.title, { color: text, borderBottomColor: divider }]}>{title}</Text>
+      ) : null}
+      <ScrollView style={styles.listScroll} contentContainerStyle={styles.list} bounces={false}>
+        {items.map((it) =>
+          it.staticRow ? (
+            <View key={it.key} style={styles.row}>
+              {it.label ? (
+                <Text
+                  style={[styles.rowText, { color: text }]}
+                  numberOfLines={1}
+                  ellipsizeMode="tail"
+                >
+                  {it.label}
+                </Text>
+              ) : null}
+              {it.right ? <View style={styles.rowRight}>{it.right}</View> : null}
+            </View>
+          ) : (
+            <Pressable
+              key={it.key}
+              onPress={() => {
+                if (it.disabled) return;
+                it.onPress?.();
+              }}
+              hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
+              style={({ pressed }) => [
+                styles.row,
+                styles.rowBtn,
+                { backgroundColor: btnBg, borderColor: btnBorder, borderWidth: btnBorderWidth },
+                !it.right ? styles.rowCenter : null,
+                it.disabled ? styles.rowDisabled : null,
+                pressed && !it.disabled ? { backgroundColor: pressedBg } : null,
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel={it.label}
+            >
+              <Text
+                style={[
+                  styles.rowText,
+                  { color: text },
+                  !it.right ? styles.rowTextCenter : null,
+                ]}
+                numberOfLines={1}
+                ellipsizeMode="tail"
+              >
+                {it.label}
+              </Text>
+              {it.right ? <View style={styles.rowRight}>{it.right}</View> : null}
+            </Pressable>
+          ),
+        )}
+      </ScrollView>
+    </>
+  );
+
+  const cardStyle = [
+    styles.card,
+    {
+      backgroundColor: cardBg,
+      borderColor: border,
+      width: cardWidth,
+      ...(hasAnchor
+        ? {
+            position: 'absolute' as const,
+            top: anchorTop,
+            left: cardLeft,
+            maxHeight: maxCardH,
+          }
+        : null),
+    },
+  ];
+
+  // On iOS, render the menu as a View overlay so closing it doesn't leave a Modal in the tree.
+  // The next screen (Chats, About, etc.) can then use a Modal and present immediately.
+  // Use explicit window dimensions and top:0, left:0 so the overlay matches Modal positioning.
+  if (Platform.OS === 'ios') {
+    if (!open) return <></>;
+    return (
+      <View
+        style={[
+          StyleSheet.absoluteFill,
+          {
+            zIndex: 10000,
+            width: windowWidth,
+            height: windowHeight,
+            top: 0,
+            left: 0,
+          },
+        ]}
+      >
+        <View
+          style={[
+            styles.overlay,
+            hasAnchor ? styles.overlayAnchored : null,
+            hasAnchor
+              ? null
+              : {
+                  // Use minimal top so panel aligns with header; avoid double safe-area.
+                  paddingTop: 8,
+                  paddingRight: 10,
+                },
+          ]}
+        >
+          <View style={[cardStyle, { zIndex: 1 }]}>{cardContent}</View>
+          <Pressable
+            style={[StyleSheet.absoluteFill, { zIndex: 0 }]}
+            onPress={onClose}
+          />
+        </View>
+      </View>
+    );
+  }
+
   return (
     <Modal visible={mounted} transparent animationType="fade" onRequestClose={onClose}>
       <View
@@ -110,8 +251,8 @@ export function HeaderMenuModal({
           hasAnchor ? styles.overlayAnchored : null,
           hasAnchor ? null : { paddingTop: insets.top + 10, paddingRight: 10 },
         ]}
+        pointerEvents={open ? 'auto' : 'none'}
       >
-        <Pressable style={StyleSheet.absoluteFill} onPress={onClose} />
         <Animated.View
           style={[
             styles.card,
@@ -132,86 +273,13 @@ export function HeaderMenuModal({
             },
           ]}
         >
-          <View style={styles.topRightCloseRow}>
-            {headerRight ? <View style={styles.headerRightSlot}>{headerRight}</View> : null}
-            <Pressable
-              onPress={onClose}
-              style={({ pressed }) => [
-                styles.closeIconBtn,
-                {
-                  backgroundColor: btnBg,
-                  borderColor: btnBorder,
-                  borderWidth: btnBorderWidth,
-                },
-                pressed ? { opacity: 0.88 } : null,
-              ]}
-              accessibilityRole="button"
-              accessibilityLabel="Close menu"
-            >
-              <AppBrandIcon
-                isDark={isDark}
-                fit="contain"
-                slotWidth={32}
-                slotHeight={32}
-                accessible={false}
-              />
-            </Pressable>
-          </View>
-          {title ? (
-            <Text style={[styles.title, { color: text, borderBottomColor: divider }]}>{title}</Text>
-          ) : null}
-          <ScrollView style={styles.listScroll} contentContainerStyle={styles.list} bounces={false}>
-            {items.map((it) =>
-              it.staticRow ? (
-                // Static rows are used for embedded controls (like Switch).
-                <View key={it.key} style={styles.row}>
-                  {it.label ? (
-                    <Text
-                      style={[styles.rowText, { color: text }]}
-                      numberOfLines={1}
-                      ellipsizeMode="tail"
-                    >
-                      {it.label}
-                    </Text>
-                  ) : null}
-                  {it.right ? <View style={styles.rowRight}>{it.right}</View> : null}
-                </View>
-              ) : (
-                <Pressable
-                  key={it.key}
-                  onPress={() => {
-                    if (it.disabled) return;
-                    it.onPress?.();
-                  }}
-                  hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
-                  style={({ pressed }) => [
-                    styles.row,
-                    styles.rowBtn,
-                    { backgroundColor: btnBg, borderColor: btnBorder, borderWidth: btnBorderWidth },
-                    !it.right ? styles.rowCenter : null,
-                    it.disabled ? styles.rowDisabled : null,
-                    pressed && !it.disabled ? { backgroundColor: pressedBg } : null,
-                  ]}
-                  accessibilityRole="button"
-                  accessibilityLabel={it.label}
-                >
-                  <Text
-                    style={[
-                      styles.rowText,
-                      { color: text },
-                      !it.right ? styles.rowTextCenter : null,
-                    ]}
-                    numberOfLines={1}
-                    ellipsizeMode="tail"
-                  >
-                    {it.label}
-                  </Text>
-                  {it.right ? <View style={styles.rowRight}>{it.right}</View> : null}
-                </Pressable>
-              ),
-            )}
-          </ScrollView>
+          {cardContent}
         </Animated.View>
+        <Pressable
+          style={StyleSheet.absoluteFill}
+          onPress={onClose}
+          pointerEvents={open ? 'auto' : 'none'}
+        />
       </View>
     </Modal>
   );

--- a/frontend/src/components/HeaderMenuModal.tsx
+++ b/frontend/src/components/HeaderMenuModal.tsx
@@ -167,11 +167,7 @@ export function HeaderMenuModal({
               accessibilityLabel={it.label}
             >
               <Text
-                style={[
-                  styles.rowText,
-                  { color: text },
-                  !it.right ? styles.rowTextCenter : null,
-                ]}
+                style={[styles.rowText, { color: text }, !it.right ? styles.rowTextCenter : null]}
                 numberOfLines={1}
                 ellipsizeMode="tail"
               >
@@ -234,10 +230,7 @@ export function HeaderMenuModal({
           ]}
         >
           <View style={[cardStyle, { zIndex: 1 }]}>{cardContent}</View>
-          <Pressable
-            style={[StyleSheet.absoluteFill, { zIndex: 0 }]}
-            onPress={onClose}
-          />
+          <Pressable style={[StyleSheet.absoluteFill, { zIndex: 0 }]} onPress={onClose} />
         </View>
       </View>
     );

--- a/frontend/src/components/ThemeToggleRow.tsx
+++ b/frontend/src/components/ThemeToggleRow.tsx
@@ -24,7 +24,14 @@ export function ThemeToggleRow({
   styles: ThemeToggleRowStyles;
 }): React.JSX.Element {
   return (
-    <View style={[styles.themeToggle, isDark && styles.themeToggleDark]}>
+    <View
+      style={[
+        styles.themeToggle,
+        isDark && styles.themeToggleDark,
+        // iOS: native Switch is larger; use tighter padding so row fits and left padding can show.
+        Platform.OS === 'ios' && { paddingHorizontal: 6, marginLeft: 8 },
+      ]}
+    >
       <Feather
         name={isDark ? 'moon' : 'sun'}
         size={16}

--- a/frontend/src/components/media/MediaViewerModal.tsx
+++ b/frontend/src/components/media/MediaViewerModal.tsx
@@ -1,3 +1,4 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as ScreenOrientation from 'expo-screen-orientation';
 import React from 'react';
 import {
@@ -41,6 +42,7 @@ export function MediaViewerModal<S extends MediaViewerState = MediaViewerState>(
   onClose,
   onSave,
   saving,
+  saveConfirm,
 }: {
   open: boolean;
   viewerState: S;
@@ -49,6 +51,13 @@ export function MediaViewerModal<S extends MediaViewerState = MediaViewerState>(
   onClose: () => void;
   onSave?: () => void | Promise<void>;
   saving?: boolean;
+  saveConfirm?: {
+    title: string;
+    message?: string;
+    confirmText?: string;
+    cancelText?: string;
+    dontShowAgain?: { storageKey: string; label?: string };
+  };
 }): React.JSX.Element {
   const insets = useSafeAreaInsets();
   const viewerScrollRef = React.useRef<ScrollView | null>(null);
@@ -57,6 +66,75 @@ export function MediaViewerModal<S extends MediaViewerState = MediaViewerState>(
   const chromeOpacity = React.useRef(new Animated.Value(1)).current;
   const chromeLastPointerAtRef = React.useRef<number>(0);
   const isTouchWeb = Platform.OS === 'web' && isWebCoarsePointer();
+
+  const [saveConfirmOpen, setSaveConfirmOpen] = React.useState(false);
+  const [saveDontShowAgain, setSaveDontShowAgain] = React.useState(false);
+  const [saveConfirmBusy, setSaveConfirmBusy] = React.useState(false);
+
+  React.useEffect(() => {
+    // Reset any pending confirmation when the viewer closes.
+    if (open) return;
+    setSaveConfirmOpen(false);
+    setSaveDontShowAgain(false);
+    setSaveConfirmBusy(false);
+  }, [open]);
+
+  React.useEffect(() => {
+    if (!saveConfirmOpen) return;
+    setSaveDontShowAgain(false);
+    setSaveConfirmBusy(false);
+  }, [saveConfirmOpen]);
+
+  const maybeShowSaveConfirm = React.useCallback(async () => {
+    // Only iOS should use a View overlay instead of the native prompt Modal.
+    if (Platform.OS !== 'ios' || !saveConfirm || !onSave) {
+      void onSave?.();
+      return;
+    }
+
+    const dontShowKey = String(saveConfirm.dontShowAgain?.storageKey || '').trim();
+    if (dontShowKey) {
+      try {
+        const v = await AsyncStorage.getItem(dontShowKey);
+        if (v === '1') {
+          void onSave();
+          return;
+        }
+      } catch {
+        // Best-effort: fall back to showing the confirmation.
+      }
+    }
+
+    setSaveConfirmOpen(true);
+  }, [onSave, saveConfirm]);
+
+  const confirmSave = React.useCallback(async () => {
+    if (!onSave || !saveConfirm) return;
+    if (saveConfirmBusy) return;
+    setSaveConfirmBusy(true);
+
+    try {
+      setSaveConfirmOpen(false);
+
+      const dontShowKey = String(saveConfirm.dontShowAgain?.storageKey || '').trim();
+      if (saveDontShowAgain && dontShowKey) {
+        try {
+          await AsyncStorage.setItem(dontShowKey, '1');
+        } catch {
+          // ignore (user choice still applies for this tap)
+        }
+      }
+
+      await onSave();
+    } finally {
+      setSaveConfirmBusy(false);
+    }
+  }, [onSave, saveConfirm, saveConfirmBusy, saveDontShowAgain]);
+
+  const cancelSaveConfirm = React.useCallback(() => {
+    if (saveConfirmBusy) return;
+    setSaveConfirmOpen(false);
+  }, [saveConfirmBusy]);
 
   const getItemAt = React.useCallback(
     (vs: S, i: number): MediaViewerGlobalItem | null => {
@@ -255,7 +333,9 @@ export function MediaViewerModal<S extends MediaViewerState = MediaViewerState>(
                 <Pressable
                   style={[styles.viewerCloseBtn, saving ? { opacity: 0.6 } : null]}
                   disabled={!!saving}
-                  onPress={() => void onSave()}
+                  onPress={() => {
+                    void maybeShowSaveConfirm();
+                  }}
                 >
                   <Text style={styles.viewerCloseText}>{saving ? 'Saving…' : 'Save'}</Text>
                 </Pressable>
@@ -265,6 +345,79 @@ export function MediaViewerModal<S extends MediaViewerState = MediaViewerState>(
               </Pressable>
             </View>
           </Animated.View>
+
+          {/* iOS: avoid nested-native-modal stacking by rendering confirmation as a View overlay. */}
+          {Platform.OS === 'ios' && saveConfirmOpen && saveConfirm ? (
+            <View style={styles.saveConfirmOverlay} pointerEvents="auto">
+              <View style={styles.saveConfirmCard}>
+                <Text style={styles.saveConfirmTitle}>{saveConfirm.title}</Text>
+                {saveConfirm.message ? (
+                  <Text style={styles.saveConfirmMessage}>{saveConfirm.message}</Text>
+                ) : null}
+
+                {saveConfirm.dontShowAgain?.label ? (
+                  <View style={styles.saveConfirmCheckboxRow}>
+                    <Pressable
+                      accessibilityRole="checkbox"
+                      accessibilityLabel={saveConfirm.dontShowAgain.label}
+                      accessibilityState={{ checked: saveDontShowAgain }}
+                      onPress={() => {
+                        if (saveConfirmBusy) return;
+                        setSaveDontShowAgain((v) => !v);
+                      }}
+                      style={({ pressed }) => [
+                        styles.saveConfirmCheckboxBtn,
+                        pressed ? { opacity: 0.9 } : null,
+                      ]}
+                    >
+                      <View
+                        style={[
+                          styles.saveConfirmCheckboxBox,
+                          saveDontShowAgain ? styles.saveConfirmCheckboxBoxChecked : null,
+                        ]}
+                      >
+                        {saveDontShowAgain ? (
+                          <Text style={styles.saveConfirmCheckboxCheck}>✓</Text>
+                        ) : null}
+                      </View>
+                      <Text style={styles.saveConfirmCheckboxLabel}>
+                        {saveConfirm.dontShowAgain.label}
+                      </Text>
+                    </Pressable>
+                  </View>
+                ) : null}
+
+                <View style={styles.saveConfirmButtons}>
+                  <Pressable
+                    style={[
+                      styles.saveConfirmButton,
+                      styles.saveConfirmButtonPrimary,
+                      saveConfirmBusy || saving ? { opacity: 0.6 } : null,
+                    ]}
+                    disabled={saveConfirmBusy || !!saving}
+                    onPress={() => void confirmSave()}
+                  >
+                    <Text style={styles.saveConfirmButtonTextPrimary}>
+                      {saveConfirm.confirmText || 'Save'}
+                    </Text>
+                  </Pressable>
+                  <Pressable
+                    style={[
+                      styles.saveConfirmButton,
+                      styles.saveConfirmButtonSecondary,
+                      saveConfirmBusy || saving ? { opacity: 0.6 } : null,
+                    ]}
+                    disabled={saveConfirmBusy || !!saving}
+                    onPress={cancelSaveConfirm}
+                  >
+                    <Text style={styles.saveConfirmButtonTextSecondary}>
+                      {saveConfirm.cancelText || 'Cancel'}
+                    </Text>
+                  </Pressable>
+                </View>
+              </View>
+            </View>
+          ) : null}
 
           <View style={styles.viewerBody}>
             {(() => {
@@ -722,4 +875,82 @@ const styles = StyleSheet.create({
   viewerImage: { width: '100%', height: '100%' },
   viewerVideo: { width: '100%', height: '100%' },
   viewerFallback: { color: APP_COLORS.dark.text.primary },
+  saveConfirmOverlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: withAlpha(PALETTE.black, 0.45),
+    zIndex: 100,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 20,
+  },
+  saveConfirmCard: {
+    width: '100%',
+    backgroundColor: withAlpha(PALETTE.black, 0.78),
+    borderRadius: 14,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: withAlpha(PALETTE.white, 0.18),
+    padding: 18,
+    elevation: 8,
+  },
+  saveConfirmTitle: {
+    color: APP_COLORS.dark.text.primary,
+    fontWeight: '700',
+    fontSize: 18,
+    marginBottom: 8,
+  },
+  saveConfirmMessage: {
+    color: withAlpha(PALETTE.white, 0.75),
+    fontWeight: '500',
+    fontSize: 14,
+    marginBottom: 14,
+  },
+  saveConfirmCheckboxRow: { alignSelf: 'stretch', marginBottom: 14 },
+  saveConfirmCheckboxBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  saveConfirmCheckboxBox: {
+    width: 22,
+    height: 22,
+    borderRadius: 6,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: withAlpha(PALETTE.white, 0.35),
+    backgroundColor: withAlpha(PALETTE.black, 0.25),
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  saveConfirmCheckboxBoxChecked: {
+    backgroundColor: withAlpha(PALETTE.white, 0.12),
+    borderColor: withAlpha(PALETTE.white, 0.65),
+  },
+  saveConfirmCheckboxCheck: {
+    color: APP_COLORS.dark.text.primary,
+    fontWeight: '900',
+    fontSize: 16,
+    lineHeight: 16,
+  },
+  saveConfirmCheckboxLabel: {
+    color: withAlpha(PALETTE.white, 0.85),
+    fontWeight: '600',
+    fontSize: 13,
+  },
+  saveConfirmButtons: { flexDirection: 'row', gap: 10 },
+  saveConfirmButton: {
+    flex: 1,
+    paddingVertical: 10,
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: withAlpha(PALETTE.white, 0.16),
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  saveConfirmButtonPrimary: { backgroundColor: withAlpha(PALETTE.white, 0.14) },
+  saveConfirmButtonSecondary: { backgroundColor: withAlpha(PALETTE.black, 0.05) },
+  saveConfirmButtonTextPrimary: { color: APP_COLORS.dark.text.primary, fontWeight: '800' },
+  saveConfirmButtonTextSecondary: { color: withAlpha(PALETTE.white, 0.8), fontWeight: '800' },
 });

--- a/frontend/src/features/appShell/components/MainAppBackgroundModal.tsx
+++ b/frontend/src/features/appShell/components/MainAppBackgroundModal.tsx
@@ -313,7 +313,7 @@ export function MainAppBackgroundModal({
                   style={[
                     styles.modalHelperText,
                     isDark ? styles.modalHelperTextDark : null,
-                    { marginTop: 6 },
+                    { marginTop: 6, marginBottom: 4 },
                   ]}
                 >
                   Photo background enabled - remove the photo to use a solid color
@@ -322,18 +322,19 @@ export function MainAppBackgroundModal({
 
               {photoEnabled ? (
                 <>
-                  <View style={styles.bgEffectsHeaderRow}>
+                  <View style={[styles.bgEffectsHeaderRow, { marginTop: 2 }]}>
                     <Text
                       style={[
                         styles.modalHelperText,
                         isDark ? styles.modalHelperTextDark : null,
                         styles.profileSectionTitle,
+                        { marginTop: 0, marginBottom: 0 },
                       ]}
                     >
-                      Image scale
+                      Image Scale
                     </Text>
                   </View>
-                  <View style={[styles.avatarTextColorRow, { marginTop: 6 }]}>
+                  <View style={[styles.avatarTextColorRow, { marginTop: 4 }]}>
                     <Pressable
                       onPress={() => setBgImageScaleModeDraft('fill')}
                       style={[
@@ -382,12 +383,13 @@ export function MainAppBackgroundModal({
                     </Pressable>
                   </View>
 
-                  <View style={styles.bgEffectsHeaderRow}>
+                  <View style={[styles.bgEffectsHeaderRow, { marginTop: 4 }]}>
                     <Text
                       style={[
                         styles.modalHelperText,
                         isDark ? styles.modalHelperTextDark : null,
                         styles.profileSectionTitle,
+                        { marginTop: 0, marginBottom: 0 },
                       ]}
                     >
                       Photo effects
@@ -416,7 +418,7 @@ export function MainAppBackgroundModal({
                     </Pressable>
                   </View>
 
-                  <View style={styles.bgSliderSection}>
+                  <View style={[styles.bgSliderSection, { marginTop: 6 }]}>
                     <View style={styles.bgSliderLabelRow}>
                       <Text
                         style={[styles.bgSliderLabel, isDark ? styles.bgSliderLabelDark : null]}

--- a/frontend/src/features/appShell/components/MainAppBlocklistModal.tsx
+++ b/frontend/src/features/appShell/components/MainAppBlocklistModal.tsx
@@ -11,6 +11,9 @@ import {
 } from '../../../hooks/useKeyboardOverlap';
 import { APP_COLORS } from '../../../theme/colors';
 
+/** iOS: avoid Modal + UiPromptModal (unblock confirm) stacking native modals. */
+const BLOCKLIST_IOS_OVERLAY_Z = 50000;
+
 export function MainAppBlocklistModal({
   styles,
   isDark,
@@ -59,13 +62,8 @@ export function MainAppBlocklistModal({
       ),
     [kb.keyboardVisible, kb.remainingOverlap, kb.windowHeight, sheetHeight],
   );
-  return (
-    <Modal
-      visible={blocklistOpen}
-      transparent
-      animationType="fade"
-      onRequestClose={() => setBlocklistOpen(false)}
-    >
+  const sheet = (
+    <>
       <View
         style={[
           styles.modalOverlay,
@@ -214,6 +212,31 @@ export function MainAppBlocklistModal({
           </View>
         </View>
       </View>
+    </>
+  );
+
+  // iOS: Modal + UiPromptModal (unblock confirm) stacks native modals and can freeze / swallow updates.
+  // Render as an in-tree overlay (MainAppContent places this last so z-order is above chat).
+  if (Platform.OS === 'ios') {
+    if (!blocklistOpen) return null;
+    return (
+      <View
+        pointerEvents="box-none"
+        style={[StyleSheet.absoluteFillObject, { zIndex: BLOCKLIST_IOS_OVERLAY_Z }]}
+      >
+        {sheet}
+      </View>
+    );
+  }
+
+  return (
+    <Modal
+      visible={blocklistOpen}
+      transparent
+      animationType="fade"
+      onRequestClose={() => setBlocklistOpen(false)}
+    >
+      {sheet}
     </Modal>
   );
 }

--- a/frontend/src/features/appShell/components/MainAppBlocklistModal.tsx
+++ b/frontend/src/features/appShell/components/MainAppBlocklistModal.tsx
@@ -46,7 +46,7 @@ export function MainAppBlocklistModal({
     blockedUsernameLower?: string;
   }>;
   unblockUser: (sub: string, label?: string) => void | Promise<void>;
-}): React.JSX.Element {
+}): React.JSX.Element | null {
   const kb = useKeyboardOverlap({ enabled: blocklistOpen });
   const [sheetHeight, setSheetHeight] = React.useState<number>(0);
   const bottomPad = React.useMemo(

--- a/frontend/src/features/appShell/components/MainAppChannelsModals.tsx
+++ b/frontend/src/features/appShell/components/MainAppChannelsModals.tsx
@@ -702,9 +702,7 @@ export function MainAppChannelsModals({
                     maxWidth: 400,
                     borderRadius: 14,
                     padding: 16,
-                    backgroundColor: isDark
-                      ? APP_COLORS.dark.bg.surface
-                      : APP_COLORS.light.bg.app,
+                    backgroundColor: isDark ? APP_COLORS.dark.bg.surface : APP_COLORS.light.bg.app,
                   }}
                 >
                   <Text style={[styles.modalTitle, isDark ? styles.modalTitleDark : null]}>
@@ -717,7 +715,9 @@ export function MainAppChannelsModals({
                   </Text>
 
                   {leaveIosPrompt.kind === 'alert' ? (
-                    <View style={[styles.modalButtons, { marginTop: 14, justifyContent: 'flex-end' }]}>
+                    <View
+                      style={[styles.modalButtons, { marginTop: 14, justifyContent: 'flex-end' }]}
+                    >
                       <Pressable
                         style={[
                           styles.modalButton,
@@ -783,7 +783,10 @@ export function MainAppChannelsModals({
                         accessibilityLabel={leaveIosPrompt.cancelText}
                       >
                         <Text
-                          style={[styles.modalButtonText, isDark ? styles.modalButtonTextDark : null]}
+                          style={[
+                            styles.modalButtonText,
+                            isDark ? styles.modalButtonTextDark : null,
+                          ]}
                         >
                           {leaveIosPrompt.cancelText}
                         </Text>

--- a/frontend/src/features/appShell/components/MainAppChannelsModals.tsx
+++ b/frontend/src/features/appShell/components/MainAppChannelsModals.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../../hooks/useKeyboardOverlap';
 import { APP_COLORS } from '../../../theme/colors';
 import { shouldShowGlobalForChannelSearch } from '../../../utils/channelSearch';
+import type { LeaveChannelDecision, LeaveChannelResult } from '../hooks/useChannelsFlow';
 
 type ChannelSearchResult = {
   channelId: string;
@@ -42,6 +43,8 @@ export function MainAppChannelsModals({
   myChannels,
   enterChannelConversation,
   leaveChannelFromSettings,
+  getLeaveChannelDecisionForIos,
+  leaveChannelFromSettingsIosConfirmed,
   // Inline create channel
   createChannelOpen,
   setCreateChannelOpen,
@@ -91,6 +94,9 @@ export function MainAppChannelsModals({
   myChannels: Array<{ channelId: string; name: string; isPublic?: boolean; hasPassword?: boolean }>;
   enterChannelConversation: (conversationId: string) => void;
   leaveChannelFromSettings: (channelId: string) => void | Promise<void>;
+  // iOS: render leave confirmations as a View overlay inside this modal tree.
+  getLeaveChannelDecisionForIos: (channelId: string) => Promise<LeaveChannelDecision>;
+  leaveChannelFromSettingsIosConfirmed: (channelId: string) => Promise<LeaveChannelResult>;
 
   createChannelOpen: boolean;
   setCreateChannelOpen: React.Dispatch<React.SetStateAction<boolean>>;
@@ -216,6 +222,89 @@ export function MainAppChannelsModals({
     setChannelPasswordVisible(false);
   }, [channelPasswordPrompt]);
 
+  type IosLeavePrompt =
+    | {
+        kind: 'confirm';
+        channelId: string;
+        title: string;
+        message: string;
+        confirmText: string;
+        cancelText: string;
+      }
+    | {
+        kind: 'alert';
+        channelId: string;
+        title: string;
+        message: string;
+      };
+
+  const [leaveIosPrompt, setLeaveIosPrompt] = React.useState<IosLeavePrompt | null>(null);
+  const [leaveIosBusy, setLeaveIosBusy] = React.useState<boolean>(false);
+
+  const beginIosLeaveFlow = React.useCallback(
+    async (channelId: string) => {
+      if (leaveIosBusy) return;
+      const cid = String(channelId || '').trim();
+      if (!cid) return;
+
+      setLeaveIosBusy(true);
+      try {
+        const decision = await getLeaveChannelDecisionForIos(cid);
+        if (decision.kind === 'block') {
+          setLeaveIosPrompt({
+            kind: 'alert',
+            channelId: cid,
+            title: decision.title,
+            message: decision.message,
+          });
+          return;
+        }
+
+        setLeaveIosPrompt({
+          kind: 'confirm',
+          channelId: cid,
+          title: decision.title,
+          message: decision.message,
+          confirmText: decision.confirmText,
+          cancelText: decision.cancelText,
+        });
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : 'Unable to leave';
+        setLeaveIosPrompt({
+          kind: 'alert',
+          channelId: cid,
+          title: 'Unable to leave',
+          message,
+        });
+      } finally {
+        setLeaveIosBusy(false);
+      }
+    },
+    [getLeaveChannelDecisionForIos, leaveIosBusy],
+  );
+
+  const confirmIosLeave = React.useCallback(async () => {
+    if (!leaveIosPrompt || leaveIosPrompt.kind !== 'confirm') return;
+    if (leaveIosBusy) return;
+
+    setLeaveIosBusy(true);
+    try {
+      const res = await leaveChannelFromSettingsIosConfirmed(leaveIosPrompt.channelId);
+      if (res.ok) {
+        setLeaveIosPrompt(null);
+        return;
+      }
+      setLeaveIosPrompt({
+        kind: 'alert',
+        channelId: leaveIosPrompt.channelId,
+        title: res.title,
+        message: res.message,
+      });
+    } finally {
+      setLeaveIosBusy(false);
+    }
+  }, [leaveChannelFromSettingsIosConfirmed, leaveIosBusy, leaveIosPrompt]);
+
   return (
     <>
       {/* Settings → Channels: list joined channels (like Chats) */}
@@ -233,13 +322,28 @@ export function MainAppChannelsModals({
               : null,
           ]}
         >
-          <Pressable style={StyleSheet.absoluteFill} onPress={() => setChannelsOpen(false)} />
+          <Pressable
+            style={StyleSheet.absoluteFill}
+            onPress={() => {
+              if (leaveIosPrompt) return;
+              if (leaveIosBusy) return;
+              setChannelsOpen(false);
+            }}
+          />
           <View
             style={[
               styles.chatsCard,
               isDark ? styles.chatsCardDark : null,
               Platform.OS !== 'web' && channelsKb.keyboardVisible
                 ? { maxHeight: channelsKb.availableHeightAboveKeyboard, minHeight: 0 }
+                : null,
+              // iOS leave overlay: `chatsCard` hairline border sits outside the dim layer’s fill and
+              // reads as a bright ring in light mode — hide it while the overlay is up.
+              Platform.OS === 'ios' && leaveIosPrompt
+                ? {
+                    borderWidth: 0,
+                    overflow: 'hidden',
+                  }
                 : null,
             ]}
             onLayout={(e) => {
@@ -511,7 +615,13 @@ export function MainAppChannelsModals({
                     </View>
                     <View style={[styles.chatRowRight, { marginLeft: 10 }]}>
                       <Pressable
-                        onPress={() => void Promise.resolve(leaveChannelFromSettings(c.channelId))}
+                        onPress={() => {
+                          if (Platform.OS === 'ios') {
+                            void Promise.resolve(beginIosLeaveFlow(c.channelId));
+                            return;
+                          }
+                          void Promise.resolve(leaveChannelFromSettings(c.channelId));
+                        }}
                         style={({ pressed }) => [
                           styles.leaveChip,
                           isDark ? styles.leaveChipDark : null,
@@ -569,6 +679,120 @@ export function MainAppChannelsModals({
                 </Text>
               </Pressable>
             </View>
+
+            {Platform.OS === 'ios' && leaveIosPrompt ? (
+              <View
+                style={[
+                  StyleSheet.absoluteFillObject,
+                  {
+                    // Match parent `chatsCard` radius so dim + corners align (avoids a visible “ring”).
+                    borderRadius: 16,
+                    overflow: 'hidden',
+                    backgroundColor: 'rgba(0,0,0,0.45)',
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                    zIndex: 999,
+                  },
+                ]}
+              >
+                {/* Do not reuse `chatsCard` here — it adds a hairline border and stacks with the parent card. */}
+                <View
+                  style={{
+                    width: '88%',
+                    maxWidth: 400,
+                    borderRadius: 14,
+                    padding: 16,
+                    backgroundColor: isDark
+                      ? APP_COLORS.dark.bg.surface
+                      : APP_COLORS.light.bg.app,
+                  }}
+                >
+                  <Text style={[styles.modalTitle, isDark ? styles.modalTitleDark : null]}>
+                    {leaveIosPrompt.title}
+                  </Text>
+                  <Text
+                    style={[styles.modalHelperText, isDark ? styles.modalHelperTextDark : null]}
+                  >
+                    {leaveIosPrompt.message}
+                  </Text>
+
+                  {leaveIosPrompt.kind === 'alert' ? (
+                    <View style={[styles.modalButtons, { marginTop: 14, justifyContent: 'flex-end' }]}>
+                      <Pressable
+                        style={[
+                          styles.modalButton,
+                          styles.modalButtonSmall,
+                          styles.modalButtonCta,
+                          isDark ? styles.modalButtonCtaDark : null,
+                          leaveIosBusy ? { opacity: 0.7 } : null,
+                        ]}
+                        onPress={() => {
+                          if (leaveIosBusy) return;
+                          setLeaveIosPrompt(null);
+                        }}
+                        accessibilityRole="button"
+                        accessibilityLabel="OK"
+                      >
+                        <Text style={[styles.modalButtonText, styles.modalButtonCtaText]}>OK</Text>
+                      </Pressable>
+                    </View>
+                  ) : (
+                    <View
+                      style={{
+                        flexDirection: 'row',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                        marginTop: 14,
+                        gap: 8,
+                        width: '100%',
+                      }}
+                    >
+                      <Pressable
+                        style={[
+                          styles.modalButton,
+                          styles.modalButtonSmall,
+                          styles.modalButtonCta,
+                          isDark ? styles.modalButtonCtaDark : null,
+                          leaveIosBusy ? { opacity: 0.7 } : null,
+                          { flex: 1 },
+                        ]}
+                        onPress={() => {
+                          if (leaveIosBusy) return;
+                          void Promise.resolve(confirmIosLeave());
+                        }}
+                        accessibilityRole="button"
+                        accessibilityLabel={leaveIosPrompt.confirmText}
+                      >
+                        <Text style={[styles.modalButtonText, styles.modalButtonCtaText]}>
+                          {leaveIosBusy ? 'Leaving…' : leaveIosPrompt.confirmText}
+                        </Text>
+                      </Pressable>
+                      <Pressable
+                        style={[
+                          styles.modalButton,
+                          styles.modalButtonSmall,
+                          isDark ? styles.modalButtonDark : null,
+                          leaveIosBusy ? { opacity: 0.7 } : null,
+                          { flex: 1 },
+                        ]}
+                        onPress={() => {
+                          if (leaveIosBusy) return;
+                          setLeaveIosPrompt(null);
+                        }}
+                        accessibilityRole="button"
+                        accessibilityLabel={leaveIosPrompt.cancelText}
+                      >
+                        <Text
+                          style={[styles.modalButtonText, isDark ? styles.modalButtonTextDark : null]}
+                        >
+                          {leaveIosPrompt.cancelText}
+                        </Text>
+                      </Pressable>
+                    </View>
+                  )}
+                </View>
+              </View>
+            ) : null}
           </View>
         </View>
       </Modal>

--- a/frontend/src/features/appShell/components/MainAppChatsAndRecoveryModals.tsx
+++ b/frontend/src/features/appShell/components/MainAppChatsAndRecoveryModals.tsx
@@ -93,6 +93,137 @@ export function MainAppChatsAndRecoveryModals({
       ),
     [chatsKb.keyboardVisible, chatsKb.remainingOverlap, chatsKb.windowHeight, chatsSheetHeight],
   );
+
+  // Chats panel content (shared by Modal and iOS View overlay).
+  const chatsPanelContent = (
+    <View
+      style={[
+        styles.modalOverlay,
+        Platform.OS !== 'web' && chatsBottomPad > 0 ? { paddingBottom: chatsBottomPad } : null,
+      ]}
+    >
+      <Pressable style={StyleSheet.absoluteFill} onPress={() => setChatsOpen(false)} />
+      <View
+        style={[
+          styles.chatsCard,
+          isDark ? styles.chatsCardDark : null,
+          Platform.OS !== 'web' && chatsKb.keyboardVisible
+            ? { maxHeight: chatsKb.availableHeightAboveKeyboard, minHeight: 0 }
+            : null,
+        ]}
+        onLayout={(e) => {
+          const h = e?.nativeEvent?.layout?.height;
+          if (typeof h === 'number' && Number.isFinite(h) && h > 0) setChatsSheetHeight(h);
+        }}
+      >
+        <View style={styles.chatsTopRow}>
+          <Text style={[styles.modalTitle, isDark ? styles.modalTitleDark : null]}>Chats</Text>
+        </View>
+        <ScrollView style={styles.chatsScroll}>
+          {chatsLoading ? (
+            <View style={styles.chatsLoadingRow}>
+              <Text
+                style={[
+                  styles.modalHelperText,
+                  isDark ? styles.modalHelperTextDark : null,
+                  styles.chatsLoadingText,
+                ]}
+              >
+                Loading
+              </Text>
+              <View style={styles.chatsLoadingDotsWrap}>
+                <AnimatedDots
+                  color={isDark ? APP_COLORS.dark.text.primary : APP_COLORS.light.text.primary}
+                  size={18}
+                />
+              </View>
+            </View>
+          ) : chatsList.length ? (
+            chatsList.map((t) => (
+              <Pressable
+                key={`chat:${t.conversationId}`}
+                style={({ pressed }) => [
+                  styles.chatRow,
+                  isDark ? styles.chatRowDark : null,
+                  pressed ? { opacity: 0.9 } : null,
+                ]}
+                onPress={() => {
+                  setChatsOpen(false);
+                  goToConversation(t.conversationId);
+                }}
+              >
+                <View style={styles.chatRowLeft}>
+                  <Text
+                    style={[styles.chatRowName, isDark ? styles.chatRowNameDark : null]}
+                    numberOfLines={1}
+                  >
+                    {t.peer || 'Direct Message'}
+                  </Text>
+                </View>
+                <View style={styles.chatRowRight}>
+                  {t.lastActivityAt ? (
+                    <Text
+                      style={[styles.chatRowDate, isDark ? styles.chatRowDateDark : null]}
+                      numberOfLines={1}
+                      accessibilityLabel="Last message date"
+                    >
+                      {formatChatActivityDate(t.lastActivityAt)}
+                    </Text>
+                  ) : null}
+                  {(t.unreadCount || 0) > 0 ? (
+                    <View style={[styles.unreadChip, isDark ? styles.unreadChipDark : null]}>
+                      <Text
+                        style={[styles.unreadChipText, isDark ? styles.unreadChipTextDark : null]}
+                      >
+                        {t.unreadCount}
+                      </Text>
+                    </View>
+                  ) : null}
+                  <Pressable
+                    onPress={() =>
+                      void Promise.resolve(deleteConversationFromList(t.conversationId))
+                    }
+                    style={({ pressed }) => [
+                      styles.chatDeleteBtn,
+                      isDark ? styles.chatDeleteBtnDark : null,
+                      pressed ? { opacity: 0.85 } : null,
+                    ]}
+                    accessibilityRole="button"
+                    accessibilityLabel="Remove chat"
+                  >
+                    <Feather
+                      name="trash-2"
+                      size={16}
+                      color={isDark ? APP_COLORS.dark.text.primary : APP_COLORS.light.text.primary}
+                    />
+                  </Pressable>
+                </View>
+              </Pressable>
+            ))
+          ) : (
+            <Text style={[styles.modalHelperText, isDark ? styles.modalHelperTextDark : null]}>
+              No active chats
+            </Text>
+          )}
+        </ScrollView>
+        <View style={styles.modalButtons}>
+          <Pressable
+            style={[
+              styles.modalButton,
+              styles.modalButtonSmall,
+              isDark ? styles.modalButtonDark : null,
+            ]}
+            onPress={() => setChatsOpen(false)}
+          >
+            <Text style={[styles.modalButtonText, isDark ? styles.modalButtonTextDark : null]}>
+              Close
+            </Text>
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+
   return (
     <>
       <Modal
@@ -245,137 +376,7 @@ export function MainAppChatsAndRecoveryModals({
         animationType="fade"
         onRequestClose={() => setChatsOpen(false)}
       >
-        <View
-          style={[
-            styles.modalOverlay,
-            Platform.OS !== 'web' && chatsBottomPad > 0 ? { paddingBottom: chatsBottomPad } : null,
-          ]}
-        >
-          <Pressable style={StyleSheet.absoluteFill} onPress={() => setChatsOpen(false)} />
-          <View
-            style={[
-              styles.chatsCard,
-              isDark ? styles.chatsCardDark : null,
-              Platform.OS !== 'web' && chatsKb.keyboardVisible
-                ? { maxHeight: chatsKb.availableHeightAboveKeyboard, minHeight: 0 }
-                : null,
-            ]}
-            onLayout={(e) => {
-              const h = e?.nativeEvent?.layout?.height;
-              if (typeof h === 'number' && Number.isFinite(h) && h > 0) setChatsSheetHeight(h);
-            }}
-          >
-            <View style={styles.chatsTopRow}>
-              <Text style={[styles.modalTitle, isDark ? styles.modalTitleDark : null]}>Chats</Text>
-            </View>
-            <ScrollView style={styles.chatsScroll}>
-              {chatsLoading ? (
-                <View style={styles.chatsLoadingRow}>
-                  <Text
-                    style={[
-                      styles.modalHelperText,
-                      isDark ? styles.modalHelperTextDark : null,
-                      styles.chatsLoadingText,
-                    ]}
-                  >
-                    Loading
-                  </Text>
-                  <View style={styles.chatsLoadingDotsWrap}>
-                    <AnimatedDots
-                      color={isDark ? APP_COLORS.dark.text.primary : APP_COLORS.light.text.primary}
-                      size={18}
-                    />
-                  </View>
-                </View>
-              ) : chatsList.length ? (
-                chatsList.map((t) => (
-                  <Pressable
-                    key={`chat:${t.conversationId}`}
-                    style={({ pressed }) => [
-                      styles.chatRow,
-                      isDark ? styles.chatRowDark : null,
-                      pressed ? { opacity: 0.9 } : null,
-                    ]}
-                    onPress={() => {
-                      setChatsOpen(false);
-                      goToConversation(t.conversationId);
-                    }}
-                  >
-                    <View style={styles.chatRowLeft}>
-                      <Text
-                        style={[styles.chatRowName, isDark ? styles.chatRowNameDark : null]}
-                        numberOfLines={1}
-                      >
-                        {t.peer || 'Direct Message'}
-                      </Text>
-                    </View>
-                    <View style={styles.chatRowRight}>
-                      {t.lastActivityAt ? (
-                        <Text
-                          style={[styles.chatRowDate, isDark ? styles.chatRowDateDark : null]}
-                          numberOfLines={1}
-                          accessibilityLabel="Last message date"
-                        >
-                          {formatChatActivityDate(t.lastActivityAt)}
-                        </Text>
-                      ) : null}
-                      {(t.unreadCount || 0) > 0 ? (
-                        <View style={[styles.unreadChip, isDark ? styles.unreadChipDark : null]}>
-                          <Text
-                            style={[
-                              styles.unreadChipText,
-                              isDark ? styles.unreadChipTextDark : null,
-                            ]}
-                          >
-                            {t.unreadCount}
-                          </Text>
-                        </View>
-                      ) : null}
-                      <Pressable
-                        onPress={() =>
-                          void Promise.resolve(deleteConversationFromList(t.conversationId))
-                        }
-                        style={({ pressed }) => [
-                          styles.chatDeleteBtn,
-                          isDark ? styles.chatDeleteBtnDark : null,
-                          pressed ? { opacity: 0.85 } : null,
-                        ]}
-                        accessibilityRole="button"
-                        accessibilityLabel="Remove chat"
-                      >
-                        <Feather
-                          name="trash-2"
-                          size={16}
-                          color={
-                            isDark ? APP_COLORS.dark.text.primary : APP_COLORS.light.text.primary
-                          }
-                        />
-                      </Pressable>
-                    </View>
-                  </Pressable>
-                ))
-              ) : (
-                <Text style={[styles.modalHelperText, isDark ? styles.modalHelperTextDark : null]}>
-                  No active chats
-                </Text>
-              )}
-            </ScrollView>
-            <View style={styles.modalButtons}>
-              <Pressable
-                style={[
-                  styles.modalButton,
-                  styles.modalButtonSmall,
-                  isDark ? styles.modalButtonDark : null,
-                ]}
-                onPress={() => setChatsOpen(false)}
-              >
-                <Text style={[styles.modalButtonText, isDark ? styles.modalButtonTextDark : null]}>
-                  Close
-                </Text>
-              </Pressable>
-            </View>
-          </View>
-        </View>
+        {chatsPanelContent}
       </Modal>
     </>
   );

--- a/frontend/src/features/appShell/components/MainAppContent.tsx
+++ b/frontend/src/features/appShell/components/MainAppContent.tsx
@@ -827,21 +827,6 @@ export const MainAppContent = ({
         submitChannelPassword={submitChannelPassword}
       />
 
-      <MainAppBlocklistModal
-        styles={styles}
-        isDark={isDark}
-        blocklistOpen={blocklistOpen}
-        setBlocklistOpen={setBlocklistOpen}
-        blockUsername={blockUsername}
-        setBlockUsername={setBlockUsername}
-        blockError={blockError}
-        setBlockError={setBlockError}
-        addBlockByUsername={addBlockByUsername}
-        blocklistLoading={blocklistLoading}
-        blockedUsers={blockedUsers}
-        unblockUser={unblockUser}
-      />
-
       <MainAppPassphrasePromptModal styles={styles} isDark={isDark} {...passphraseModalProps} />
 
       <View style={{ flex: 1 }}>
@@ -878,6 +863,22 @@ export const MainAppContent = ({
           <View style={{ flex: 1, backgroundColor: appColors.appBackground }} />
         )}
       </View>
+
+      {/* After main chat so iOS blocklist overlay (View, not Modal) paints above the thread. */}
+      <MainAppBlocklistModal
+        styles={styles}
+        isDark={isDark}
+        blocklistOpen={blocklistOpen}
+        setBlocklistOpen={setBlocklistOpen}
+        blockUsername={blockUsername}
+        setBlockUsername={setBlockUsername}
+        blockError={blockError}
+        setBlockError={setBlockError}
+        addBlockByUsername={addBlockByUsername}
+        blocklistLoading={blocklistLoading}
+        blockedUsers={blockedUsers}
+        unblockUser={unblockUser}
+      />
     </View>
   );
 };

--- a/frontend/src/features/appShell/components/MainAppContent.tsx
+++ b/frontend/src/features/appShell/components/MainAppContent.tsx
@@ -353,6 +353,8 @@ export const MainAppContent = ({
     setMyChannelsError,
     myChannels,
     leaveChannelFromSettings,
+    getLeaveChannelDecisionForIos,
+    leaveChannelFromSettingsIosConfirmed,
     createChannelOpen,
     setCreateChannelOpen,
     createChannelName,
@@ -784,6 +786,8 @@ export const MainAppContent = ({
         myChannels={myChannels}
         enterChannelConversation={enterChannelConversation}
         leaveChannelFromSettings={leaveChannelFromSettings}
+        getLeaveChannelDecisionForIos={getLeaveChannelDecisionForIos}
+        leaveChannelFromSettingsIosConfirmed={leaveChannelFromSettingsIosConfirmed}
         createChannelOpen={createChannelOpen}
         setCreateChannelOpen={setCreateChannelOpen}
         createChannelName={createChannelName}

--- a/frontend/src/features/appShell/components/MainAppMenuAndAboutOverlays.tsx
+++ b/frontend/src/features/appShell/components/MainAppMenuAndAboutOverlays.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Modal, Platform, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import type { AppStyles } from '../../../../App.styles';
 import { GlobalAboutContent } from '../../../components/globalAbout/GlobalAboutContent';
@@ -117,6 +117,12 @@ export function MainAppMenuAndAboutOverlays({
   globalAboutOpen: boolean;
   dismissGlobalAbout: () => void | Promise<void>;
 }): React.JSX.Element {
+  // On iOS, defer opening the next panel by one frame so the menu view is gone before the next Modal presents.
+  const scheduleOpen = React.useCallback((fn: () => void) => {
+    if (Platform.OS === 'ios') requestAnimationFrame(fn);
+    else fn();
+  }, []);
+
   const items = React.useMemo(() => {
     const base: Array<{ key: string; label: string; onPress: () => void | Promise<void> }> = [];
 
@@ -126,15 +132,11 @@ export function MainAppMenuAndAboutOverlays({
         label: 'About',
         onPress: () => {
           setMenuOpen(false);
-          // About is tied to the Channels-side conversation (Global or a channel).
           const cid = String(activeChannelConversationId || '').trim() || 'global';
           if (cid === 'global') {
             setGlobalAboutOpen(true);
-            return;
-          }
-          if (cid.startsWith('ch#')) {
+          } else if (cid.startsWith('ch#')) {
             setChannelAboutRequestEpoch((v) => v + 1);
-            return;
           }
         },
       });
@@ -146,7 +148,7 @@ export function MainAppMenuAndAboutOverlays({
         label: 'Chats',
         onPress: () => {
           setMenuOpen(false);
-          setChatsOpen(true);
+          scheduleOpen(() => setChatsOpen(true));
         },
       },
       {
@@ -154,17 +156,19 @@ export function MainAppMenuAndAboutOverlays({
         label: 'Channels',
         onPress: () => {
           setMenuOpen(false);
-          setMyChannelsError(null);
-          setCreateChannelError(null);
-          setCreateChannelOpen(false);
-          setCreateChannelName('');
-          setCreateChannelPassword('');
-          setCreateChannelIsPublic(true);
-          setChannelSearchOpen(false);
-          setChannelsError(null);
-          setChannelJoinError(null);
-          setChannelsQuery('');
-          setChannelsOpen(true);
+          scheduleOpen(() => {
+            setMyChannelsError(null);
+            setCreateChannelError(null);
+            setCreateChannelOpen(false);
+            setCreateChannelName('');
+            setCreateChannelPassword('');
+            setCreateChannelIsPublic(true);
+            setChannelSearchOpen(false);
+            setChannelsError(null);
+            setChannelJoinError(null);
+            setChannelsQuery('');
+            setChannelsOpen(true);
+          });
         },
       },
       {
@@ -172,8 +176,10 @@ export function MainAppMenuAndAboutOverlays({
         label: 'Avatar',
         onPress: () => {
           setMenuOpen(false);
-          setAvatarError(null);
-          setAvatarOpen(true);
+          scheduleOpen(() => {
+            setAvatarError(null);
+            setAvatarOpen(true);
+          });
         },
       },
       {
@@ -181,23 +187,27 @@ export function MainAppMenuAndAboutOverlays({
         label: 'Background',
         onPress: () => {
           setMenuOpen(false);
-          setBackgroundError(null);
-          setBackgroundOpen(true);
+          scheduleOpen(() => {
+            setBackgroundError(null);
+            setBackgroundOpen(true);
+          });
         },
       },
       {
         key: 'recovery',
         label: 'Recovery',
-        onPress: async () => {
+        onPress: () => {
           setMenuOpen(false);
-          setRecoveryOpen(true);
-          // After a Metro refresh, Amplify may take a moment to rehydrate tokens.
-          // Refresh recovery state so the modal shows "Change" vs "Set up" correctly.
-          const token = await getIdTokenWithRetry({ maxAttempts: 10, delayMs: 200 });
-          if (token) {
-            const exists = await checkRecoveryBlobExists(token);
-            if (exists !== null) applyRecoveryBlobExists(exists);
-          }
+          scheduleOpen(() => {
+            setRecoveryOpen(true);
+            void (async () => {
+              const token = await getIdTokenWithRetry({ maxAttempts: 10, delayMs: 200 });
+              if (token) {
+                const exists = await checkRecoveryBlobExists(token);
+                if (exists !== null) applyRecoveryBlobExists(exists);
+              }
+            })();
+          });
         },
       },
       {
@@ -205,15 +215,15 @@ export function MainAppMenuAndAboutOverlays({
         label: 'Blocklist',
         onPress: () => {
           setMenuOpen(false);
-          setBlocklistOpen(true);
+          scheduleOpen(() => setBlocklistOpen(true));
         },
       },
       {
         key: 'deleteAccount',
         label: 'Delete account',
-        onPress: async () => {
+        onPress: () => {
           setMenuOpen(false);
-          await deleteMyAccount();
+          scheduleOpen(() => void deleteMyAccount());
         },
       },
       {
@@ -233,6 +243,7 @@ export function MainAppMenuAndAboutOverlays({
 
     return base;
   }, [
+    scheduleOpen,
     activeChannelConversationId,
     applyRecoveryBlobExists,
     checkRecoveryBlobExists,
@@ -296,7 +307,6 @@ export function MainAppMenuAndAboutOverlays({
                 bodyStyle={[
                   styles.modalHelperText,
                   ...(isDark ? [styles.modalHelperTextDark] : []),
-                  // Slightly more comfortable reading in the About modal.
                   { marginBottom: 0 },
                 ]}
               />

--- a/frontend/src/features/appShell/components/MainAppPassphrasePromptModal.tsx
+++ b/frontend/src/features/appShell/components/MainAppPassphrasePromptModal.tsx
@@ -1,7 +1,7 @@
 import { icons } from '@aws-amplify/ui-react-native/dist/assets';
 import React from 'react';
 import type { TextInput } from 'react-native';
-import { Image, Modal, Platform, Pressable, Text, View } from 'react-native';
+import { Image, Modal, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import type { AppStyles } from '../../../../App.styles';
 import { AnimatedDots } from '../../../components/AnimatedDots';
@@ -33,6 +33,10 @@ export function MainAppPassphrasePromptModal({
   processing,
   onSubmit,
   onCancel,
+
+  skipRecoveryConfirmVisible,
+  onConfirmSkipRecovery,
+  onDismissSkipRecovery,
 }: {
   styles: AppStyles;
   isDark: boolean;
@@ -52,6 +56,10 @@ export function MainAppPassphrasePromptModal({
   processing: boolean;
   onSubmit: () => void;
   onCancel: () => void | Promise<void>;
+
+  skipRecoveryConfirmVisible: boolean;
+  onConfirmSkipRecovery: () => void;
+  onDismissSkipRecovery: () => void;
 }): React.JSX.Element {
   const kb = useKeyboardOverlap({ enabled: visible });
   const [sheetHeight, setSheetHeight] = React.useState<number>(0);
@@ -101,13 +109,24 @@ export function MainAppPassphrasePromptModal({
     mode === 'restore'
       ? 'Decrypting'
       : mode === 'change'
-        ? 'Updating backup'
+        ? 'Updating'
         : mode === 'reset'
-          ? 'Resetting recovery'
-          : 'Encrypting backup';
+          ? 'Resetting'
+          : 'Encrypting';
 
   const content = (
-    <View style={[styles.modalContent, isDark ? styles.modalContentDark : null]}>
+    <View
+      style={[
+        styles.modalContent,
+        isDark ? styles.modalContentDark : null,
+        Platform.OS === 'ios' && skipRecoveryConfirmVisible
+          ? {
+              borderWidth: 0,
+              overflow: 'hidden',
+            }
+          : null,
+      ]}
+    >
       <Text style={[styles.modalTitle, isDark ? styles.modalTitleDark : null]}>{label}</Text>
       {helperText ? (
         <Text style={[styles.modalHelperText, isDark ? styles.modalHelperTextDark : null]}>
@@ -225,20 +244,30 @@ export function MainAppPassphrasePromptModal({
             submitDisabled && { opacity: 0.45 },
           ]}
           onPress={onSubmit}
-          disabled={submitDisabled}
+          disabled={submitDisabled || skipRecoveryConfirmVisible}
         >
           {processing ? (
-            <View
-              style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                justifyContent: 'center',
-                gap: 2,
-              }}
-            >
-              <Text style={[styles.modalButtonText, styles.modalButtonCtaText]}>{busyLabel}</Text>
-              <AnimatedDots color={APP_COLORS.dark.text.primary} size={18} />
-            </View>
+            mode === 'reset' || mode === 'setup' || mode === 'change' ? (
+              // Setup / change / reset: short label only (no dots) — long label + dots overflowed narrow CTA on iOS.
+              <Text
+                style={[styles.modalButtonText, styles.modalButtonCtaText, { textAlign: 'center' }]}
+              >
+                {busyLabel}
+              </Text>
+            ) : (
+              <View
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  gap: 2,
+                  width: '100%',
+                }}
+              >
+                <Text style={[styles.modalButtonText, styles.modalButtonCtaText]}>{busyLabel}</Text>
+                <AnimatedDots color={APP_COLORS.dark.text.primary} size={18} />
+              </View>
+            )
           ) : (
             <Text style={[styles.modalButtonText, styles.modalButtonCtaText]}>Submit</Text>
           )}
@@ -251,13 +280,89 @@ export function MainAppPassphrasePromptModal({
             processing && { opacity: 0.45 },
           ]}
           onPress={() => void Promise.resolve(onCancel())}
-          disabled={processing}
+          disabled={processing || skipRecoveryConfirmVisible}
         >
           <Text style={[styles.modalButtonText, isDark ? styles.modalButtonTextDark : null]}>
             Cancel
           </Text>
         </Pressable>
       </View>
+
+      {Platform.OS === 'ios' && skipRecoveryConfirmVisible && mode === 'setup' ? (
+        <View
+          style={[
+            StyleSheet.absoluteFillObject,
+            {
+              borderRadius: 12,
+              overflow: 'hidden',
+              backgroundColor: 'rgba(0,0,0,0.45)',
+              justifyContent: 'center',
+              alignItems: 'center',
+              zIndex: 999,
+              padding: 12,
+            },
+          ]}
+        >
+          <View
+            style={{
+              width: '100%',
+              maxWidth: 360,
+              borderRadius: 14,
+              padding: 16,
+              backgroundColor: isDark
+                ? APP_COLORS.dark.bg.surface
+                : APP_COLORS.light.bg.app,
+            }}
+          >
+            <Text style={[styles.modalTitle, isDark ? styles.modalTitleDark : null]}>
+              Skip Recovery Setup?
+            </Text>
+            <Text
+              style={[styles.modalHelperText, isDark ? styles.modalHelperTextDark : null]}
+            >
+              {
+                "If you don't set a recovery passphrase, you won't be able to restore older encrypted messages if you switch devices.\n\nWe do NOT store your passphrase, so make sure you remember it."
+              }
+            </Text>
+            <View
+              style={{
+                flexDirection: 'row',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                marginTop: 14,
+                gap: 8,
+                width: '100%',
+              }}
+            >
+              <Pressable
+                style={[
+                  styles.modalButton,
+                  styles.modalButtonSmall,
+                  styles.modalButtonCta,
+                  isDark ? styles.modalButtonCtaDark : null,
+                ]}
+                onPress={onConfirmSkipRecovery}
+                accessibilityRole="button"
+                accessibilityLabel="Skip for now"
+              >
+                <Text style={[styles.modalButtonText, styles.modalButtonCtaText]}>
+                  Skip for now
+                </Text>
+              </Pressable>
+              <Pressable
+                style={[styles.modalButton, styles.modalButtonSmall, isDark ? styles.modalButtonDark : null]}
+                onPress={onDismissSkipRecovery}
+                accessibilityRole="button"
+                accessibilityLabel="Go back"
+              >
+                <Text style={[styles.modalButtonText, isDark ? styles.modalButtonTextDark : null]}>
+                  Go back
+                </Text>
+              </Pressable>
+            </View>
+          </View>
+        </View>
+      ) : null}
     </View>
   );
 

--- a/frontend/src/features/appShell/components/MainAppPassphrasePromptModal.tsx
+++ b/frontend/src/features/appShell/components/MainAppPassphrasePromptModal.tsx
@@ -309,17 +309,13 @@ export function MainAppPassphrasePromptModal({
               maxWidth: 360,
               borderRadius: 14,
               padding: 16,
-              backgroundColor: isDark
-                ? APP_COLORS.dark.bg.surface
-                : APP_COLORS.light.bg.app,
+              backgroundColor: isDark ? APP_COLORS.dark.bg.surface : APP_COLORS.light.bg.app,
             }}
           >
             <Text style={[styles.modalTitle, isDark ? styles.modalTitleDark : null]}>
               Skip Recovery Setup?
             </Text>
-            <Text
-              style={[styles.modalHelperText, isDark ? styles.modalHelperTextDark : null]}
-            >
+            <Text style={[styles.modalHelperText, isDark ? styles.modalHelperTextDark : null]}>
               {
                 "If you don't set a recovery passphrase, you won't be able to restore older encrypted messages if you switch devices.\n\nWe do NOT store your passphrase, so make sure you remember it."
               }
@@ -350,7 +346,11 @@ export function MainAppPassphrasePromptModal({
                 </Text>
               </Pressable>
               <Pressable
-                style={[styles.modalButton, styles.modalButtonSmall, isDark ? styles.modalButtonDark : null]}
+                style={[
+                  styles.modalButton,
+                  styles.modalButtonSmall,
+                  isDark ? styles.modalButtonDark : null,
+                ]}
                 onPress={onDismissSkipRecovery}
                 accessibilityRole="button"
                 accessibilityLabel="Go back"

--- a/frontend/src/features/appShell/hooks/useBlocklistData.ts
+++ b/frontend/src/features/appShell/hooks/useBlocklistData.ts
@@ -195,8 +195,8 @@ export function useBlocklistData({
       const subToUnblock = String(blockedSub || '').trim();
       if (!subToUnblock || !apiUrl) return;
       const ok = await promptConfirm(
-        'Unblock user?',
-        `Unblock ${label ? `"${label}"` : 'this user'}?`,
+        'Unblock User?',
+        `Unblock ${label ? `${label}` : 'this user'}?`,
         { confirmText: 'Unblock', cancelText: 'Cancel', destructive: false },
       );
       if (!ok) return;

--- a/frontend/src/features/appShell/hooks/useChannelsFlow.ts
+++ b/frontend/src/features/appShell/hooks/useChannelsFlow.ts
@@ -28,6 +28,25 @@ export type ChannelSearchResult = {
   isMember?: boolean;
 };
 
+export type LeaveChannelDecision =
+  | {
+      kind: 'block';
+      title: string;
+      message: string;
+    }
+  | {
+      kind: 'confirm';
+      title: string;
+      message: string;
+      confirmText: string;
+      cancelText: string;
+      destructive?: boolean;
+    };
+
+export type LeaveChannelResult =
+  | { ok: true }
+  | { ok: false; title: string; message: string };
+
 export function useChannelsFlow({
   apiUrl,
   getIdToken,
@@ -70,6 +89,10 @@ export function useChannelsFlow({
   }>;
   fetchMyChannels: () => Promise<void>;
   leaveChannelFromSettings: (channelId: string) => Promise<void>;
+  // iOS: avoid nested native modal stacking by letting the Channels modal render
+  // the confirmation/alert as a View overlay.
+  getLeaveChannelDecisionForIos: (channelId: string) => Promise<LeaveChannelDecision>;
+  leaveChannelFromSettingsIosConfirmed: (channelId: string) => Promise<LeaveChannelResult>;
 
   // Find Channels
   channelSearchOpen: boolean;
@@ -517,7 +540,9 @@ export function useChannelsFlow({
                 'You are the last member in this channel.\n\nIf you leave, the channel and its message history will be deleted.\n\nYou can recreate the channel later.',
                 { confirmText: 'Leave & Delete', cancelText: 'Cancel', destructive: true },
               );
-              if (!ok) return;
+              if (!ok) {
+                return;
+              }
               // This prompt is the confirmation; do not show a second "Leave channel?" modal.
               skipStandardConfirm = true;
             }
@@ -527,12 +552,14 @@ export function useChannelsFlow({
         }
 
         if (!skipStandardConfirm) {
-          const ok = await promptConfirm('Leave channel?', 'You will stop receiving new messages', {
+          const ok = await promptConfirm('Leave Channel?', 'You will stop receiving new messages', {
             confirmText: 'Leave',
             cancelText: 'Cancel',
             destructive: true,
           });
-          if (!ok) return;
+          if (!ok) {
+            return;
+          }
         }
 
         const resp = await fetch(`${base}/channels/leave`, {
@@ -573,7 +600,158 @@ export function useChannelsFlow({
         void promptAlert('Unable to leave', e instanceof Error ? e.message : 'Leave failed');
       }
     },
-    [apiUrl, currentConversationId, enterChannelConversation, promptAlert, promptConfirm],
+    [
+      apiUrl,
+      currentConversationId,
+      enterChannelConversation,
+      promptAlert,
+      promptConfirm,
+    ],
+  );
+
+  const getLeaveChannelDecisionForIos = React.useCallback(
+    async (channelId: string): Promise<LeaveChannelDecision> => {
+      const cid = String(channelId || '').trim();
+      if (!cid) {
+        return {
+          kind: 'block',
+          title: 'Unable to leave',
+          message: 'Invalid channel.',
+        };
+      }
+      if (!apiUrl) {
+        return {
+          kind: 'block',
+          title: 'Unable to leave',
+          message: 'Backend not configured.',
+        };
+      }
+
+      const token = await getIdTokenRef.current();
+      if (!token) {
+        throw new Error('Unable to authenticate');
+      }
+
+      const base = apiUrl.replace(/\/$/, '');
+      try {
+        const rosterResp = await fetch(
+          `${base}/channels/members?channelId=${encodeURIComponent(cid)}`,
+          {
+            headers: { Authorization: `Bearer ${token}` },
+          },
+        );
+        if (rosterResp.ok) {
+          const raw: unknown = await rosterResp.json().catch(() => ({}));
+          const data =
+            raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : ({} as const);
+
+          const me = data.me && typeof data.me === 'object' ? (data.me as Record<string, unknown>) : {};
+          const meIsAdmin = !!me.isAdmin;
+
+          const membersRaw: unknown[] = Array.isArray(data.members) ? data.members : [];
+          const members = membersRaw
+            .map((m) => (m && typeof m === 'object' ? (m as Record<string, unknown>) : null))
+            .filter(Boolean) as Array<Record<string, unknown>>;
+
+          const active = members.filter((m) => String(m.status || '') === 'active');
+          const activeAdmins = active.filter((m) => !!m.isAdmin);
+
+          // If I'm an admin, and there are other active members, require at least one *other* active admin.
+          if (meIsAdmin && active.length > 1 && activeAdmins.length === 1) {
+            return {
+              kind: 'block',
+              title: 'Wait!',
+              message: 'You are the last admin. Promote someone else before leaving.',
+            };
+          }
+
+          if (active.length === 1) {
+            return {
+              kind: 'confirm',
+              title: 'Leave and Delete Channel?',
+              message:
+                'You are the last member in this channel.\n\nIf you leave, the channel and its message history will be deleted.\n\nYou can recreate the channel later.',
+              confirmText: 'Leave & Delete',
+              cancelText: 'Cancel',
+              destructive: true,
+            };
+          }
+        }
+      } catch {
+        // ignore and fall back to basic confirm
+      }
+
+      return {
+        kind: 'confirm',
+        title: 'Leave Channel?',
+        message: 'You will stop receiving new messages',
+        confirmText: 'Leave',
+        cancelText: 'Cancel',
+        destructive: true,
+      };
+    },
+    [apiUrl],
+  );
+
+  const leaveChannelFromSettingsIosConfirmed = React.useCallback(
+    async (channelId: string): Promise<LeaveChannelResult> => {
+      const cid = String(channelId || '').trim();
+      if (!cid) return { ok: false, title: 'Unable to leave', message: 'Invalid channel.' };
+      if (!apiUrl) return { ok: false, title: 'Unable to leave', message: 'Backend not configured.' };
+
+      const leavingActiveChannel = String(currentConversationId || '').trim() === `ch#${cid}`;
+
+      try {
+        const token = await getIdTokenRef.current();
+        if (!token) throw new Error('Unable to authenticate');
+
+        const base = apiUrl.replace(/\/$/, '');
+        const resp = await fetch(`${base}/channels/leave`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ channelId: cid }),
+        });
+
+        if (!resp.ok) {
+          const text = await resp.text().catch(() => '');
+          let msg = `Leave failed (${resp.status})`;
+          try {
+            const parsed = text ? JSON.parse(text) : null;
+            if (parsed && typeof parsed.message === 'string') msg = parsed.message;
+          } catch {
+            if (text.trim()) msg = `${msg}: ${text.trim()}`;
+          }
+
+          const looksLikeLastAdmin =
+            String(msg || '')
+              .toLowerCase()
+              .includes('last admin') &&
+            String(msg || '')
+              .toLowerCase()
+              .includes('promote');
+
+          return { ok: false, title: looksLikeLastAdmin ? 'Wait!' : 'Unable to leave', message: msg };
+        }
+
+        setMyChannels((prev) =>
+          (Array.isArray(prev) ? prev : []).filter((c) => String(c.channelId) !== cid),
+        );
+
+        // If we left the channel currently being viewed, behave like the in-channel leave action:
+        // navigate back to Global and close any channel modals.
+        if (leavingActiveChannel) {
+          enterChannelConversation('global');
+        } else {
+          setChannelsOpen(false);
+        }
+
+        return { ok: true };
+      } catch (e: unknown) {
+        const message = e instanceof Error ? e.message : 'Leave failed';
+        return { ok: false, title: 'Unable to leave', message };
+      }
+    },
+    [apiUrl, currentConversationId, enterChannelConversation],
   );
 
   const submitCreateChannelInline = React.useCallback(async () => {
@@ -662,6 +840,8 @@ export function useChannelsFlow({
     myChannels,
     fetchMyChannels,
     leaveChannelFromSettings,
+    getLeaveChannelDecisionForIos,
+    leaveChannelFromSettingsIosConfirmed,
 
     channelSearchOpen,
     setChannelSearchOpen,

--- a/frontend/src/features/appShell/hooks/useChannelsFlow.ts
+++ b/frontend/src/features/appShell/hooks/useChannelsFlow.ts
@@ -43,9 +43,7 @@ export type LeaveChannelDecision =
       destructive?: boolean;
     };
 
-export type LeaveChannelResult =
-  | { ok: true }
-  | { ok: false; title: string; message: string };
+export type LeaveChannelResult = { ok: true } | { ok: false; title: string; message: string };
 
 export function useChannelsFlow({
   apiUrl,
@@ -600,13 +598,7 @@ export function useChannelsFlow({
         void promptAlert('Unable to leave', e instanceof Error ? e.message : 'Leave failed');
       }
     },
-    [
-      apiUrl,
-      currentConversationId,
-      enterChannelConversation,
-      promptAlert,
-      promptConfirm,
-    ],
+    [apiUrl, currentConversationId, enterChannelConversation, promptAlert, promptConfirm],
   );
 
   const getLeaveChannelDecisionForIos = React.useCallback(
@@ -645,7 +637,8 @@ export function useChannelsFlow({
           const data =
             raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : ({} as const);
 
-          const me = data.me && typeof data.me === 'object' ? (data.me as Record<string, unknown>) : {};
+          const me =
+            data.me && typeof data.me === 'object' ? (data.me as Record<string, unknown>) : {};
           const meIsAdmin = !!me.isAdmin;
 
           const membersRaw: unknown[] = Array.isArray(data.members) ? data.members : [];
@@ -697,7 +690,8 @@ export function useChannelsFlow({
     async (channelId: string): Promise<LeaveChannelResult> => {
       const cid = String(channelId || '').trim();
       if (!cid) return { ok: false, title: 'Unable to leave', message: 'Invalid channel.' };
-      if (!apiUrl) return { ok: false, title: 'Unable to leave', message: 'Backend not configured.' };
+      if (!apiUrl)
+        return { ok: false, title: 'Unable to leave', message: 'Backend not configured.' };
 
       const leavingActiveChannel = String(currentConversationId || '').trim() === `ch#${cid}`;
 
@@ -730,7 +724,11 @@ export function useChannelsFlow({
               .toLowerCase()
               .includes('promote');
 
-          return { ok: false, title: looksLikeLastAdmin ? 'Wait!' : 'Unable to leave', message: msg };
+          return {
+            ok: false,
+            title: looksLikeLastAdmin ? 'Wait!' : 'Unable to leave',
+            message: msg,
+          };
         }
 
         setMyChannels((prev) =>

--- a/frontend/src/features/appShell/hooks/usePassphrasePrompt.ts
+++ b/frontend/src/features/appShell/hooks/usePassphrasePrompt.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Platform } from 'react-native';
 
 type PassphrasePromptMode = 'setup' | 'restore' | 'change' | 'reset';
 
@@ -48,6 +49,10 @@ export function usePassphrasePrompt({
     processing: boolean;
     onSubmit: () => void;
     onCancel: () => void;
+    /** iOS: skip confirmation uses a View overlay instead of `promptConfirm` (nested native Modal freeze). */
+    skipRecoveryConfirmVisible: boolean;
+    onConfirmSkipRecovery: () => void;
+    onDismissSkipRecovery: () => void;
   };
 } {
   const [passphrasePrompt, setPassphrasePrompt] = React.useState<PassphrasePromptState>(null);
@@ -56,14 +61,31 @@ export function usePassphrasePrompt({
   const [passphraseVisible, setPassphraseVisible] = React.useState(false);
   const [passphraseError, setPassphraseError] = React.useState<string | null>(null);
   const [processing, setProcessing] = React.useState(false);
+  const [skipRecoveryConfirmVisible, setSkipRecoveryConfirmVisible] = React.useState(false);
+  const activePromptRef = React.useRef<PassphrasePromptState | null>(null);
+  React.useEffect(() => {
+    activePromptRef.current = passphrasePrompt;
+  }, [passphrasePrompt]);
 
   const closePrompt = React.useCallback(() => {
+    setSkipRecoveryConfirmVisible(false);
     setPassphrasePrompt(null);
     setPassphraseInput('');
     setPassphraseConfirmInput('');
     setPassphraseVisible(false);
     setPassphraseError(null);
     setProcessing(false);
+  }, []);
+
+  const onConfirmSkipRecovery = React.useCallback(() => {
+    setSkipRecoveryConfirmVisible(false);
+    const p = activePromptRef.current;
+    if (p) p.reject(new Error('Prompt cancelled'));
+    closePrompt();
+  }, [closePrompt]);
+
+  const onDismissSkipRecovery = React.useCallback(() => {
+    setSkipRecoveryConfirmVisible(false);
   }, []);
 
   const promptPassphrase = React.useCallback((mode: PassphrasePromptMode): Promise<string> => {
@@ -132,6 +154,11 @@ export function usePassphrasePrompt({
       }
 
       // Setup flow: user is choosing to skip creating a recovery passphrase.
+      // iOS: avoid stacking UiPromptModal on top of this screen’s native Modal (freezes / unresponsive UI).
+      if (Platform.OS === 'ios') {
+        setSkipRecoveryConfirmVisible(true);
+        return;
+      }
       const ok = await promptConfirm(
         'Skip Recovery Setup?',
         "If you don't set a recovery passphrase, you won't be able to restore older encrypted messages if you switch devices.\n\nWe do NOT store your passphrase, so make sure you remember it.",
@@ -173,6 +200,9 @@ export function usePassphrasePrompt({
       processing,
       onSubmit: handlePromptSubmit,
       onCancel: handlePromptCancel,
+      skipRecoveryConfirmVisible,
+      onConfirmSkipRecovery,
+      onDismissSkipRecovery,
     },
   };
 }

--- a/frontend/src/features/appShell/hooks/useRecoveryFlow.ts
+++ b/frontend/src/features/appShell/hooks/useRecoveryFlow.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import type { BackupBlob } from '../../../types/crypto';
+import { deferForModalTransition } from '../../../utils/deferForModalTransition';
 
 export function useRecoveryFlow({
   apiUrl,
@@ -91,7 +92,9 @@ export function useRecoveryFlow({
       setHasRecoveryBlob(true);
       setRecoveryBlobKnown(true);
       setRecoveryLocked(false);
-      await promptAlert('Recovery reset', 'A new recovery passphrase has been set.');
+      closePrompt();
+      await deferForModalTransition();
+      await promptAlert('Recovery Reset', 'A new recovery passphrase has been set.');
     } catch {
       // cancelled setup
     } finally {
@@ -150,9 +153,13 @@ export function useRecoveryFlow({
         setHasRecoveryBlob(true);
         setRecoveryBlobKnown(true);
         setRecoveryLocked(false);
+        closePrompt();
+        await deferForModalTransition();
         await promptAlert('Recovery Unlocked', 'Your recovery passphrase has been accepted');
         return;
       } catch {
+        closePrompt();
+        await deferForModalTransition();
         await promptAlert(
           'Incorrect passphrase',
           'You have entered an incorrect passphrase. Try again.',
@@ -199,7 +206,9 @@ export function useRecoveryFlow({
       await uploadRecoveryBlob(token, kp.privateKey, nextPass);
       setHasRecoveryBlob(true);
       setRecoveryBlobKnown(true);
-      await promptAlert('Passphrase updated', 'Your recovery passphrase has been updated');
+      closePrompt();
+      await deferForModalTransition();
+      await promptAlert('Passphrase Updated', 'Your recovery passphrase has been updated');
     } catch {
       // cancelled
     } finally {
@@ -237,6 +246,8 @@ export function useRecoveryFlow({
       await uploadRecoveryBlob(token, kp.privateKey, pass);
       setHasRecoveryBlob(true);
       setRecoveryBlobKnown(true);
+      closePrompt();
+      await deferForModalTransition();
       await promptAlert('Recovery set up', 'A recovery passphrase has been set for your account');
     } catch {
       // cancelled

--- a/frontend/src/features/appShell/hooks/useSignedInBootstrap.ts
+++ b/frontend/src/features/appShell/hooks/useSignedInBootstrap.ts
@@ -4,6 +4,7 @@ import { Platform } from 'react-native';
 
 import type { AmplifyUiUser } from '../../../types/amplifyUi';
 import type { BackupBlob } from '../../../types/crypto';
+import { deferForModalTransition } from '../../../utils/deferForModalTransition';
 
 type KeyPair = { privateKey: string; publicKey: string } | null;
 
@@ -212,12 +213,14 @@ export function useSignedInBootstrap({
                   recovered = true;
                   closePrompt();
                 } catch (err) {
+                  // Dismiss passphrase modal before stacking UiPromptModal (iOS nested-modal freeze).
+                  closePrompt();
+                  await deferForModalTransition();
                   await promptAlert(
                     'Incorrect passphrase',
                     'You have entered an incorrect passphrase. Try again.',
                   );
                   console.warn('Recovery attempt failed', err);
-                  closePrompt();
                   // continue prompting
                 }
               }

--- a/frontend/src/features/chat/components/AiHelperModal.tsx
+++ b/frontend/src/features/chat/components/AiHelperModal.tsx
@@ -41,7 +41,8 @@ type Props = {
   onSubmit: () => void;
   onResetThread: () => void;
   onClose: () => void;
-  onCopySuggestion: (s: string) => void;
+  /** Return `false` when copy did not succeed (caller should not show “Copied”). */
+  onCopySuggestion: (s: string) => boolean | void | Promise<boolean | void>;
   onUseSuggestion: (s: string) => void;
 
   scrollRef: React.MutableRefObject<ScrollView | null>;
@@ -93,6 +94,8 @@ export function AiHelperModal({
 }: Props) {
   const kb = useKeyboardOverlap({ enabled: visible });
   const [sheetHeight, setSheetHeight] = React.useState<number>(0);
+  /** Inline confirmation — global toast can sit under this Modal on iOS. */
+  const [copiedSuggestionKey, setCopiedSuggestionKey] = React.useState<string | null>(null);
   const bottomPad = React.useMemo(
     () =>
       calcCenteredModalBottomPadding(
@@ -360,7 +363,23 @@ export function AiHelperModal({
                                                   styles.toolBtn,
                                                   isDark ? styles.toolBtnDark : null,
                                                 ]}
-                                                onPress={() => onCopySuggestion(s)}
+                                                onPress={async () => {
+                                                  const rowKey = `turn:${idx}:sugg:${sIdx}`;
+                                                  try {
+                                                    const ok = await Promise.resolve(
+                                                      onCopySuggestion(s),
+                                                    );
+                                                    if (ok === false) return;
+                                                    setCopiedSuggestionKey(rowKey);
+                                                    setTimeout(() => {
+                                                      setCopiedSuggestionKey((k) =>
+                                                        k === rowKey ? null : k,
+                                                      );
+                                                    }, 2000);
+                                                  } catch {
+                                                    // ignore
+                                                  }
+                                                }}
                                               >
                                                 <Text
                                                   style={[
@@ -368,7 +387,9 @@ export function AiHelperModal({
                                                     isDark ? styles.toolBtnTextDark : null,
                                                   ]}
                                                 >
-                                                  Copy
+                                                  {copiedSuggestionKey === `turn:${idx}:sugg:${sIdx}`
+                                                    ? 'Copied'
+                                                    : 'Copy'}
                                                 </Text>
                                               </Pressable>
                                               <Pressable

--- a/frontend/src/features/chat/components/AiHelperModal.tsx
+++ b/frontend/src/features/chat/components/AiHelperModal.tsx
@@ -387,7 +387,8 @@ export function AiHelperModal({
                                                     isDark ? styles.toolBtnTextDark : null,
                                                   ]}
                                                 >
-                                                  {copiedSuggestionKey === `turn:${idx}:sugg:${sIdx}`
+                                                  {copiedSuggestionKey ===
+                                                  `turn:${idx}:sugg:${sIdx}`
                                                     ? 'Copied'
                                                     : 'Copy'}
                                                 </Text>

--- a/frontend/src/features/chat/components/ChannelAboutModal.tsx
+++ b/frontend/src/features/chat/components/ChannelAboutModal.tsx
@@ -68,164 +68,168 @@ export function ChannelAboutModal({
       ),
     [kb.keyboardVisible, kb.remainingOverlap, kb.windowHeight, sheetHeight],
   );
-  return (
-    <Modal visible={visible} transparent animationType="fade" onRequestClose={onRequestClose}>
+
+  const overlayContent = (
+    <View
+      style={[
+        styles.modalOverlay,
+        Platform.OS !== 'web' && bottomPad > 0 ? { paddingBottom: bottomPad } : null,
+      ]}
+    >
+      <Pressable style={StyleSheet.absoluteFill} onPress={onBackdropPress} />
       <View
         style={[
-          styles.modalOverlay,
-          Platform.OS !== 'web' && bottomPad > 0 ? { paddingBottom: bottomPad } : null,
+          styles.summaryModal,
+          isDark ? styles.summaryModalDark : null,
+          Platform.OS !== 'web' && kb.keyboardVisible
+            ? { maxHeight: kb.availableHeightAboveKeyboard, minHeight: 0 }
+            : null,
         ]}
+        onLayout={(e) => {
+          const h = e?.nativeEvent?.layout?.height;
+          if (typeof h === 'number' && Number.isFinite(h) && h > 0) setSheetHeight(h);
+        }}
       >
-        <Pressable style={StyleSheet.absoluteFill} onPress={onBackdropPress} />
-        <View
-          style={[
-            styles.summaryModal,
-            isDark ? styles.summaryModalDark : null,
-            Platform.OS !== 'web' && kb.keyboardVisible
-              ? { maxHeight: kb.availableHeightAboveKeyboard, minHeight: 0 }
-              : null,
-          ]}
-          onLayout={(e) => {
-            const h = e?.nativeEvent?.layout?.height;
-            if (typeof h === 'number' && Number.isFinite(h) && h > 0) setSheetHeight(h);
-          }}
-        >
-          <Text style={[styles.summaryTitle, isDark ? styles.summaryTitleDark : null]}>
-            {title}
-          </Text>
+        <Text style={[styles.summaryTitle, isDark ? styles.summaryTitleDark : null]}>
+          {title}
+        </Text>
 
+        {edit ? (
+          <>
+            <Text
+              style={[
+                styles.summaryText,
+                isDark ? styles.summaryTextDark : null,
+                { marginBottom: 8 },
+              ]}
+            >
+              Supports **bold**, *italics*, and links. Max 4000 chars.
+            </Text>
+            <AppTextInput
+              isDark={isDark}
+              value={draft}
+              onChangeText={onChangeDraft}
+              placeholder="Write channel info / rules…"
+              multiline
+              autoFocus
+              textAlignVertical="top"
+              style={{
+                width: '100%',
+                minHeight: 160,
+                maxHeight: 320,
+                paddingHorizontal: 12,
+                paddingVertical: 10,
+                borderWidth: 1,
+                borderRadius: 10,
+                backgroundColor: isDark
+                  ? APP_COLORS.dark.bg.header
+                  : APP_COLORS.light.bg.surface2,
+                borderColor: isDark
+                  ? APP_COLORS.dark.border.default
+                  : APP_COLORS.light.border.subtle,
+                color: isDark ? APP_COLORS.dark.text.primary : APP_COLORS.light.text.primary,
+                fontSize: 15,
+              }}
+            />
+            <Text
+              style={[
+                styles.summaryText,
+                isDark ? styles.summaryTextDark : null,
+                { marginTop: 6 },
+              ]}
+            >
+              {`${String(draft || '').length}/4000`}
+            </Text>
+          </>
+        ) : (
+          <ScrollView style={styles.summaryScroll}>
+            {String(draft || '').trim() ? (
+              <RichText
+                text={String(draft || '')}
+                isDark={isDark}
+                style={[styles.summaryText, ...(isDark ? [styles.summaryTextDark] : [])]}
+                enableMentions={false}
+                variant="neutral"
+                onOpenUrl={onOpenUrl}
+              />
+            ) : (
+              <Text style={[styles.summaryText, isDark ? styles.summaryTextDark : null]}>
+                Welcome to {title}
+              </Text>
+            )}
+          </ScrollView>
+        )}
+
+        <View style={styles.summaryButtons}>
           {edit ? (
             <>
-              <Text
+              <Pressable
                 style={[
-                  styles.summaryText,
-                  isDark ? styles.summaryTextDark : null,
-                  { marginBottom: 8 },
+                  styles.toolBtn,
+                  isDark ? styles.toolBtnDark : null,
+                  busy ? { opacity: 0.6 } : null,
+                  { marginRight: 'auto' },
                 ]}
+                disabled={busy}
+                onPress={onPreview}
               >
-                Supports **bold**, *italics*, and links. Max 4000 chars.
-              </Text>
-              <AppTextInput
-                isDark={isDark}
-                value={draft}
-                onChangeText={onChangeDraft}
-                placeholder="Write channel info / rules…"
-                multiline
-                autoFocus
-                // Android: multiline TextInput defaults to vertically-centered text; force top-left like a real editor.
-                textAlignVertical="top"
-                style={{
-                  width: '100%',
-                  minHeight: 160,
-                  maxHeight: 320,
-                  paddingHorizontal: 12,
-                  paddingVertical: 10,
-                  borderWidth: 1,
-                  borderRadius: 10,
-                  backgroundColor: isDark
-                    ? APP_COLORS.dark.bg.header
-                    : APP_COLORS.light.bg.surface2,
-                  borderColor: isDark
-                    ? APP_COLORS.dark.border.default
-                    : APP_COLORS.light.border.subtle,
-                  color: isDark ? APP_COLORS.dark.text.primary : APP_COLORS.light.text.primary,
-                  fontSize: 15,
-                }}
-              />
-              <Text
+                <Text style={[styles.toolBtnText, isDark ? styles.toolBtnTextDark : null]}>
+                  Preview
+                </Text>
+              </Pressable>
+              <Pressable
                 style={[
-                  styles.summaryText,
-                  isDark ? styles.summaryTextDark : null,
-                  { marginTop: 6 },
+                  styles.toolBtn,
+                  isDark ? styles.toolBtnDark : null,
+                  busy ? { opacity: 0.6 } : null,
                 ]}
+                disabled={busy}
+                onPress={() => void Promise.resolve(onSave())}
               >
-                {`${String(draft || '').length}/4000`}
-              </Text>
+                <Text style={[styles.toolBtnText, isDark ? styles.toolBtnTextDark : null]}>
+                  Save
+                </Text>
+              </Pressable>
+              <Pressable
+                style={[styles.toolBtn, isDark ? styles.toolBtnDark : null]}
+                disabled={busy}
+                onPress={onCancelEdit}
+              >
+                <Text style={[styles.toolBtnText, isDark ? styles.toolBtnTextDark : null]}>
+                  Cancel
+                </Text>
+              </Pressable>
             </>
           ) : (
-            <ScrollView style={styles.summaryScroll}>
-              {String(draft || '').trim() ? (
-                <RichText
-                  text={String(draft || '')}
-                  isDark={isDark}
-                  style={[styles.summaryText, ...(isDark ? [styles.summaryTextDark] : [])]}
-                  enableMentions={false}
-                  variant="neutral"
-                  onOpenUrl={onOpenUrl}
-                />
-              ) : (
-                <Text style={[styles.summaryText, isDark ? styles.summaryTextDark : null]}>
-                  Welcome to {title}
+            <>
+              <Pressable
+                style={[styles.toolBtn, isDark ? styles.toolBtnDark : null]}
+                onPress={() => void Promise.resolve(onGotIt())}
+              >
+                <Text style={[styles.toolBtnText, isDark ? styles.toolBtnTextDark : null]}>
+                  Got it
                 </Text>
-              )}
-            </ScrollView>
+              </Pressable>
+              {canEdit ? (
+                <Pressable
+                  style={[styles.toolBtn, isDark ? styles.toolBtnDark : null]}
+                  onPress={onEdit}
+                >
+                  <Text style={[styles.toolBtnText, isDark ? styles.toolBtnTextDark : null]}>
+                    Edit
+                  </Text>
+                </Pressable>
+              ) : null}
+            </>
           )}
-
-          <View style={styles.summaryButtons}>
-            {edit ? (
-              <>
-                <Pressable
-                  style={[
-                    styles.toolBtn,
-                    isDark ? styles.toolBtnDark : null,
-                    busy ? { opacity: 0.6 } : null,
-                    { marginRight: 'auto' },
-                  ]}
-                  disabled={busy}
-                  onPress={onPreview}
-                >
-                  <Text style={[styles.toolBtnText, isDark ? styles.toolBtnTextDark : null]}>
-                    Preview
-                  </Text>
-                </Pressable>
-                <Pressable
-                  style={[
-                    styles.toolBtn,
-                    isDark ? styles.toolBtnDark : null,
-                    busy ? { opacity: 0.6 } : null,
-                  ]}
-                  disabled={busy}
-                  onPress={() => void Promise.resolve(onSave())}
-                >
-                  <Text style={[styles.toolBtnText, isDark ? styles.toolBtnTextDark : null]}>
-                    Save
-                  </Text>
-                </Pressable>
-                <Pressable
-                  style={[styles.toolBtn, isDark ? styles.toolBtnDark : null]}
-                  disabled={busy}
-                  onPress={onCancelEdit}
-                >
-                  <Text style={[styles.toolBtnText, isDark ? styles.toolBtnTextDark : null]}>
-                    Cancel
-                  </Text>
-                </Pressable>
-              </>
-            ) : (
-              <>
-                <Pressable
-                  style={[styles.toolBtn, isDark ? styles.toolBtnDark : null]}
-                  onPress={() => void Promise.resolve(onGotIt())}
-                >
-                  <Text style={[styles.toolBtnText, isDark ? styles.toolBtnTextDark : null]}>
-                    Got it
-                  </Text>
-                </Pressable>
-                {canEdit ? (
-                  <Pressable
-                    style={[styles.toolBtn, isDark ? styles.toolBtnDark : null]}
-                    onPress={onEdit}
-                  >
-                    <Text style={[styles.toolBtnText, isDark ? styles.toolBtnTextDark : null]}>
-                      Edit
-                    </Text>
-                  </Pressable>
-                ) : null}
-              </>
-            )}
-          </View>
         </View>
       </View>
+    </View>
+  );
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onRequestClose}>
+      {overlayContent}
     </Modal>
   );
 }

--- a/frontend/src/features/chat/components/ChannelAboutModal.tsx
+++ b/frontend/src/features/chat/components/ChannelAboutModal.tsx
@@ -90,9 +90,7 @@ export function ChannelAboutModal({
           if (typeof h === 'number' && Number.isFinite(h) && h > 0) setSheetHeight(h);
         }}
       >
-        <Text style={[styles.summaryTitle, isDark ? styles.summaryTitleDark : null]}>
-          {title}
-        </Text>
+        <Text style={[styles.summaryTitle, isDark ? styles.summaryTitleDark : null]}>{title}</Text>
 
         {edit ? (
           <>
@@ -121,9 +119,7 @@ export function ChannelAboutModal({
                 paddingVertical: 10,
                 borderWidth: 1,
                 borderRadius: 10,
-                backgroundColor: isDark
-                  ? APP_COLORS.dark.bg.header
-                  : APP_COLORS.light.bg.surface2,
+                backgroundColor: isDark ? APP_COLORS.dark.bg.header : APP_COLORS.light.bg.surface2,
                 borderColor: isDark
                   ? APP_COLORS.dark.border.default
                   : APP_COLORS.light.border.subtle,
@@ -132,11 +128,7 @@ export function ChannelAboutModal({
               }}
             />
             <Text
-              style={[
-                styles.summaryText,
-                isDark ? styles.summaryTextDark : null,
-                { marginTop: 6 },
-              ]}
+              style={[styles.summaryText, isDark ? styles.summaryTextDark : null, { marginTop: 6 }]}
             >
               {`${String(draft || '').length}/4000`}
             </Text>

--- a/frontend/src/features/chat/components/ChannelMembersModal.tsx
+++ b/frontend/src/features/chat/components/ChannelMembersModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { TextInput } from 'react-native';
-import { Modal, Pressable, ScrollView, Text, View } from 'react-native';
+import { Modal, Platform, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { AppTextInput } from '../../../components/AppTextInput';
 import { ChannelMembersSectionList } from '../../../components/ChannelMembersSectionList';
@@ -51,6 +51,96 @@ export function ChannelMembersModal({
   onToggleAdmin,
   onClose,
 }: Props) {
+  if (Platform.OS === 'ios') {
+    if (!visible) return <></>;
+    return (
+      <View style={[StyleSheet.absoluteFillObject, { zIndex: 10000 }]}>
+        <View style={styles.modalOverlay}>
+          <View style={[styles.summaryModal, isDark ? styles.summaryModalDark : null]}>
+            <Text style={[styles.summaryTitle, isDark ? styles.summaryTitleDark : null]}>
+              Members
+            </Text>
+            {meIsAdmin && canAddMembers ? (
+              <View style={{ marginTop: 10 }}>
+                <AppTextInput
+                  isDark={isDark}
+                  ref={(r) => {
+                    addMembersInputRef.current = r;
+                  }}
+                  value={addMembersDraft}
+                  onChangeText={onChangeAddMembersDraft}
+                  onSubmitEditing={() => {
+                    if (actionBusy) return;
+                    void Promise.resolve(onAddMembers());
+                  }}
+                  placeholder="Add usernames (comma/space separated)"
+                  style={{
+                    width: '100%',
+                    height: 48,
+                    paddingHorizontal: 12,
+                    borderWidth: 1,
+                    borderRadius: 10,
+                    backgroundColor: isDark
+                      ? APP_COLORS.dark.bg.header
+                      : APP_COLORS.light.bg.surface2,
+                    borderColor: isDark
+                      ? APP_COLORS.dark.border.default
+                      : APP_COLORS.light.border.subtle,
+                    color: isDark ? APP_COLORS.dark.text.primary : APP_COLORS.light.text.primary,
+                    fontSize: 16,
+                  }}
+                  editable
+                  returnKeyType="done"
+                />
+                <View style={[styles.summaryButtons, { justifyContent: 'flex-end' }]}>
+                  <Pressable
+                    style={[
+                      styles.toolBtn,
+                      isDark ? styles.toolBtnDark : null,
+                      actionBusy ? { opacity: 0.6 } : null,
+                    ]}
+                    disabled={actionBusy}
+                    onPress={() => void Promise.resolve(onAddMembers())}
+                  >
+                    <Text style={[styles.toolBtnText, isDark ? styles.toolBtnTextDark : null]}>
+                      Add
+                    </Text>
+                  </Pressable>
+                </View>
+              </View>
+            ) : null}
+            <ScrollView style={{ maxHeight: 520, alignSelf: 'stretch' }}>
+              <ChannelMembersSectionList
+                members={members}
+                mySub={mySub}
+                isDark={isDark}
+                styles={styles}
+                meIsAdmin={meIsAdmin}
+                actionBusy={actionBusy}
+                kickCooldownUntilBySub={kickCooldownUntilBySub}
+                avatarUrlByPath={avatarUrlByPath}
+                onBan={onBan}
+                onUnban={onUnban}
+                onKick={onKick}
+                onToggleAdmin={onToggleAdmin}
+              />
+            </ScrollView>
+            <View style={styles.summaryButtons}>
+              <Pressable
+                style={[styles.toolBtn, isDark ? styles.toolBtnDark : null]}
+                onPress={onClose}
+              >
+                <Text style={[styles.toolBtnText, isDark ? styles.toolBtnTextDark : null]}>
+                  Close
+                </Text>
+              </Pressable>
+            </View>
+          </View>
+        </View>
+      </View>
+    );
+  }
+
   return (
     <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
       <View style={styles.modalOverlay}>

--- a/frontend/src/features/chat/components/ChatComposer.tsx
+++ b/frontend/src/features/chat/components/ChatComposer.tsx
@@ -171,6 +171,10 @@ export function ChatComposer(props: {
   const MAX_INPUT_HEIGHT = 140;
   const [inputHeight, setInputHeight] = React.useState<number>(MIN_INPUT_HEIGHT);
 
+  // All platforms use inputHeight from onContentSizeChange. On iOS we avoid a fixed height in style
+  // (use only minHeight/maxHeight) so the native view can size by content and fire onContentSizeChange.
+  const effectiveInputHeight = inputHeight;
+
   const isMobileWeb = React.useMemo(() => {
     if (Platform.OS !== 'web') return false;
     try {
@@ -629,15 +633,15 @@ export function ChatComposer(props: {
             ref={(r) => {
               textInputRef.current = r;
             }}
-            // Keep the TextInput instance stable to avoid keyboard/focus glitches.
-            // We still use `inputEpoch` to reset *layout* state (see effect above), without remounting.
             key="chat-input"
             style={[
               styles.input,
               isDark ? styles.inputDark : null,
-              { height: inputHeight, maxHeight: MAX_INPUT_HEIGHT },
+              // iOS: no fixed height so the native view can size by content and fire onContentSizeChange.
+              Platform.OS === 'ios'
+                ? { minHeight: MIN_INPUT_HEIGHT, maxHeight: MAX_INPUT_HEIGHT }
+                : { height: effectiveInputHeight, maxHeight: MAX_INPUT_HEIGHT },
             ]}
-            // Keep the composer baseline stable across devices (prevents occasional clipping).
             allowFontScaling={false}
             underlineColorAndroid="transparent"
             placeholder={
@@ -656,7 +660,7 @@ export function ChatComposer(props: {
             onChangeText={onChangeInput}
             multiline
             blurOnSubmit={false}
-            scrollEnabled={inputHeight >= MAX_INPUT_HEIGHT}
+            scrollEnabled={Platform.OS === 'ios' ? true : effectiveInputHeight >= MAX_INPUT_HEIGHT}
             onContentSizeChange={(e) => {
               const hRaw = e?.nativeEvent?.contentSize?.height;
               const h =
@@ -691,8 +695,6 @@ export function ChatComposer(props: {
                       typeof (ev as { nativeEvent?: unknown }).nativeEvent === 'object' &&
                       (ev as { nativeEvent?: { isComposing?: unknown } }).nativeEvent?.isComposing
                     );
-                    // Desktop web UX: Enter sends, Shift+Enter inserts a newline.
-                    // Mobile web matches native: Enter inserts a newline; users send via the Send button.
                     if (key === 'Enter' && !shift && !isComposing && !isMobileWeb) {
                       ev.preventDefault?.();
                       ev.stopPropagation?.();

--- a/frontend/src/features/chat/components/ChatScreenMain.tsx
+++ b/frontend/src/features/chat/components/ChatScreenMain.tsx
@@ -244,6 +244,11 @@ export function ChatScreenMain({
     (Platform.OS === 'web' && list.visibleMessagesCount > 0 && !list.webPinned.ready) ||
     (list.visibleMessagesCount === 0 && !!list.API_URL && list.historyLoading);
 
+  // iOS: A positive keyboardVerticalOffset makes KeyboardAvoidingView add less padding, so the
+  // composer sits lower and the input stays just above the keyboard (visible gap). Zero or negative
+  // offset adds more padding and the keyboard can cover the input.
+  const iosKeyboardVerticalOffset = 10;
+
   return (
     <KeyboardAvoidingView
       style={styles.container}
@@ -254,6 +259,7 @@ export function ChatScreenMain({
       // On Android we do an explicit composer lift (below) based on keyboard + window resize.
       // Keeping KAV enabled on Android can create double-adjust gaps depending on IME settings.
       enabled={Platform.OS === 'ios'}
+      keyboardVerticalOffset={Platform.OS === 'ios' ? iosKeyboardVerticalOffset : 0}
     >
       {/* Stage 3 loader: center relative to the full screen (same as root spinners),
           not just the message-list area below the header. */}

--- a/frontend/src/features/chat/components/ChatScreenMain.tsx
+++ b/frontend/src/features/chat/components/ChatScreenMain.tsx
@@ -457,23 +457,23 @@ export function ChatScreenMain({
                   { minHeight: 44 },
                 ]}
               >
-                <View
-                  style={{
-                    flexDirection: 'row',
-                    alignItems: 'center',
-                    justifyContent: 'flex-end',
-                    gap: 10,
-                  }}
-                >
-                  {selection.canCopy ? (
+                {selection.count === 0 ? (
+                  <View
+                    style={{
+                      width: '100%',
+                      flexDirection: 'row',
+                      alignItems: 'center',
+                      justifyContent: 'flex-end',
+                    }}
+                  >
                     <Pressable
-                      onPress={selection.onCopy}
+                      onPress={selection.onCancel}
                       style={({ pressed }) => [
                         { height: 44, justifyContent: 'center', paddingHorizontal: 10 },
                         pressed ? { opacity: 0.85 } : null,
                       ]}
                       accessibilityRole="button"
-                      accessibilityLabel="Copy selected messages"
+                      accessibilityLabel="Cancel selection"
                     >
                       <Text
                         style={{
@@ -483,20 +483,140 @@ export function ChatScreenMain({
                           fontWeight: '900',
                         }}
                       >
-                        Copy
+                        Cancel
                       </Text>
                     </Pressable>
-                  ) : null}
+                  </View>
+                ) : selection.canDeleteForEveryone ? (
+                  <View style={{ width: '100%', rowGap: 4 }}>
+                    {/* Top: both delete actions */}
+                    <View
+                      style={{
+                        width: '100%',
+                        flexDirection: 'row',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                      }}
+                    >
+                      <Pressable
+                        onPress={selection.onDelete}
+                        style={({ pressed }) => [
+                          { height: 44, justifyContent: 'center', paddingHorizontal: 10 },
+                          pressed ? { opacity: 0.85 } : null,
+                        ]}
+                        accessibilityRole="button"
+                        accessibilityLabel="Delete selected messages for me"
+                      >
+                        <Text
+                          style={{
+                            color: isDark
+                              ? APP_COLORS.dark.text.primary
+                              : APP_COLORS.light.text.primary,
+                            fontWeight: '900',
+                          }}
+                        >
+                          Delete for me
+                        </Text>
+                      </Pressable>
 
-                  {selection.canDeleteForEveryone ? (
+                      <Pressable
+                        onPress={selection.onDeleteForEveryone}
+                        style={({ pressed }) => [
+                          { height: 44, justifyContent: 'center', paddingHorizontal: 10 },
+                          pressed ? { opacity: 0.85 } : null,
+                        ]}
+                        accessibilityRole="button"
+                        accessibilityLabel="Delete selected messages for everyone"
+                      >
+                        <Text
+                          style={{
+                            color: isDark
+                              ? APP_COLORS.dark.text.primary
+                              : APP_COLORS.light.text.primary,
+                            fontWeight: '900',
+                          }}
+                        >
+                          Delete for everyone
+                        </Text>
+                      </Pressable>
+                    </View>
+
+                    {/* Bottom: copy + cancel */}
+                    <View
+                      style={{
+                        width: '100%',
+                        flexDirection: 'row',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                      }}
+                    >
+                      {selection.canCopy ? (
+                        <Pressable
+                          onPress={selection.onCopy}
+                          style={({ pressed }) => [
+                            { height: 44, justifyContent: 'center', paddingHorizontal: 10 },
+                            pressed ? { opacity: 0.85 } : null,
+                          ]}
+                          accessibilityRole="button"
+                          accessibilityLabel="Copy selected messages"
+                        >
+                          <Text
+                            style={{
+                              color: isDark
+                                ? APP_COLORS.dark.text.primary
+                                : APP_COLORS.light.text.primary,
+                              fontWeight: '900',
+                            }}
+                          >
+                            Copy
+                          </Text>
+                        </Pressable>
+                      ) : (
+                        <View />
+                      )}
+
+                      <Pressable
+                        onPress={selection.onCancel}
+                        style={({ pressed }) => [
+                          { height: 44, justifyContent: 'center', paddingHorizontal: 10 },
+                          pressed ? { opacity: 0.85 } : null,
+                        ]}
+                        accessibilityRole="button"
+                        accessibilityLabel="Cancel selection"
+                      >
+                        <Text
+                          style={{
+                            color: isDark
+                              ? APP_COLORS.dark.text.primary
+                              : APP_COLORS.light.text.primary,
+                            fontWeight: '900',
+                          }}
+                        >
+                          Cancel
+                        </Text>
+                      </Pressable>
+                    </View>
+                  </View>
+                ) : (
+                  <View
+                    style={{
+                      width: '100%',
+                      flexDirection: 'row',
+                      flexWrap: 'wrap',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      columnGap: 8,
+                      rowGap: 4,
+                    }}
+                  >
                     <Pressable
-                      onPress={selection.onDeleteForEveryone}
+                      onPress={selection.onDelete}
                       style={({ pressed }) => [
                         { height: 44, justifyContent: 'center', paddingHorizontal: 10 },
                         pressed ? { opacity: 0.85 } : null,
                       ]}
                       accessibilityRole="button"
-                      accessibilityLabel="Delete selected messages for everyone"
+                      accessibilityLabel="Delete selected messages for me"
                     >
                       <Text
                         style={{
@@ -506,53 +626,55 @@ export function ChatScreenMain({
                           fontWeight: '900',
                         }}
                       >
-                        Delete for everyone
+                        Delete for me
                       </Text>
                     </Pressable>
-                  ) : null}
 
-                  <Pressable
-                    onPress={selection.onDelete}
-                    style={({ pressed }) => [
-                      { height: 44, justifyContent: 'center', paddingHorizontal: 10 },
-                      pressed ? { opacity: 0.85 } : null,
-                    ]}
-                    accessibilityRole="button"
-                    accessibilityLabel="Delete selected messages for me"
-                  >
-                    <Text
-                      style={{
-                        color: isDark
-                          ? APP_COLORS.dark.text.primary
-                          : APP_COLORS.light.text.primary,
-                        fontWeight: '900',
-                      }}
-                    >
-                      Delete for me
-                    </Text>
-                  </Pressable>
+                    {selection.canCopy ? (
+                      <Pressable
+                        onPress={selection.onCopy}
+                        style={({ pressed }) => [
+                          { height: 44, justifyContent: 'center', paddingHorizontal: 10 },
+                          pressed ? { opacity: 0.85 } : null,
+                        ]}
+                        accessibilityRole="button"
+                        accessibilityLabel="Copy selected messages"
+                      >
+                        <Text
+                          style={{
+                            color: isDark
+                              ? APP_COLORS.dark.text.primary
+                              : APP_COLORS.light.text.primary,
+                            fontWeight: '900',
+                          }}
+                        >
+                          Copy
+                        </Text>
+                      </Pressable>
+                    ) : null}
 
-                  <Pressable
-                    onPress={selection.onCancel}
-                    style={({ pressed }) => [
-                      { height: 44, justifyContent: 'center', paddingHorizontal: 10 },
-                      pressed ? { opacity: 0.85 } : null,
-                    ]}
-                    accessibilityRole="button"
-                    accessibilityLabel="Cancel selection"
-                  >
-                    <Text
-                      style={{
-                        color: isDark
-                          ? APP_COLORS.dark.text.primary
-                          : APP_COLORS.light.text.primary,
-                        fontWeight: '900',
-                      }}
+                    <Pressable
+                      onPress={selection.onCancel}
+                      style={({ pressed }) => [
+                        { height: 44, justifyContent: 'center', paddingHorizontal: 10 },
+                        pressed ? { opacity: 0.85 } : null,
+                      ]}
+                      accessibilityRole="button"
+                      accessibilityLabel="Cancel selection"
                     >
-                      Cancel
-                    </Text>
-                  </Pressable>
-                </View>
+                      <Text
+                        style={{
+                          color: isDark
+                            ? APP_COLORS.dark.text.primary
+                            : APP_COLORS.light.text.primary,
+                          fontWeight: '900',
+                        }}
+                      >
+                        Cancel
+                      </Text>
+                    </Pressable>
+                  </View>
+                )}
               </View>
             </View>
           ) : (

--- a/frontend/src/features/chat/components/ChatScreenOverlays.tsx
+++ b/frontend/src/features/chat/components/ChatScreenOverlays.tsx
@@ -749,12 +749,31 @@ export function ChatScreenOverlays(props: ChatScreenOverlaysProps): React.JSX.El
         setViewerState={viewer.setState}
         dmFileUriByPath={dmFileUriByPath}
         saving={viewer.saving}
+        saveConfirm={
+          Platform.OS === 'ios'
+            ? {
+                title: 'Save to Phone?',
+                message: 'Save this media to your device?',
+                confirmText: 'Save',
+                cancelText: 'Cancel',
+                dontShowAgain: {
+                  storageKey: SAVE_TO_PHONE_DONT_SHOW_AGAIN_KEY,
+                  label: SAVE_TO_PHONE_DONT_SHOW_AGAIN_LABEL,
+                },
+              }
+            : undefined
+        }
         onSave={async () => {
           if (Platform.OS === 'web') {
             await viewer.saveToDevice();
             return;
           }
-          const ok = await uiConfirm('Save to phone?', 'Save this media to your device?', {
+          if (Platform.OS === 'ios') {
+            await viewer.saveToDevice();
+            return;
+          }
+
+          const ok = await uiConfirm('Save to Phone?', 'Save this media to your device?', {
             confirmText: 'Save',
             cancelText: 'Cancel',
             dontShowAgain: {

--- a/frontend/src/features/chat/components/ChatScreenOverlays.tsx
+++ b/frontend/src/features/chat/components/ChatScreenOverlays.tsx
@@ -13,6 +13,7 @@ import {
   SAVE_TO_PHONE_DONT_SHOW_AGAIN_LABEL,
 } from '../../../utils/saveToPhonePrompt';
 import type { ChatMessage } from '../types';
+import type { ChatCopyToClipboardOptions } from '../useChatCopyToClipboard';
 import type { ChatMediaViewerState } from '../viewerTypes';
 import { AiConsentModal } from './AiConsentModal';
 import { AiHelperModal } from './AiHelperModal';
@@ -160,7 +161,7 @@ export type ChatScreenOverlaysProps = {
 
   // AI helper
   aiHelper: AiHelperController;
-  copyToClipboard: (text: string) => Promise<void>;
+  copyToClipboard: (text: string, opts?: ChatCopyToClipboardOptions) => Promise<boolean>;
   setInput: (t: string) => void;
 
   // Reporting
@@ -458,7 +459,7 @@ export function ChatScreenOverlays(props: ChatScreenOverlaysProps): React.JSX.El
         onSubmit={aiHelper.submit}
         onResetThread={aiHelper.resetHelperThread}
         onClose={aiHelper.closeHelper}
-        onCopySuggestion={(s: string) => void copyToClipboard(s)}
+        onCopySuggestion={async (s: string) => copyToClipboard(s, { skipToast: true })}
         onUseSuggestion={(s: string) => {
           setInput(s);
           aiHelper.closeHelper();
@@ -791,9 +792,11 @@ export function ChatScreenOverlays(props: ChatScreenOverlaysProps): React.JSX.El
         ? (() => {
             const toastNode = (
               <Animated.View
+                pointerEvents="none"
                 style={[
                   styles.toastWrap,
-                  ...(Platform.OS === 'web' ? [{ pointerEvents: 'none' as const }] : []),
+                  // iOS + web: toast is not wrapped in Modal — keep above main content.
+                  ...(Platform.OS !== 'android' ? [{ zIndex: 999999 } as const] : []),
                   {
                     bottom: Math.max(16, insets.bottom + 12),
                     opacity: toastAnim,
@@ -807,7 +810,6 @@ export function ChatScreenOverlays(props: ChatScreenOverlaysProps): React.JSX.El
                     ],
                   },
                 ]}
-                {...(Platform.OS === 'web' ? {} : { pointerEvents: 'none' as const })}
               >
                 <View
                   style={[
@@ -831,9 +833,14 @@ export function ChatScreenOverlays(props: ChatScreenOverlaysProps): React.JSX.El
               </Animated.View>
             );
 
-            // On native, other UI is often rendered inside Modal portals (e.g. MediaViewerModal).
-            // Render the toast in its own transparent Modal so it appears above those.
-            if (Platform.OS !== 'web') {
+            // Android: wrap in Modal so the toast stays above other full-screen Modal portals
+            // (e.g. MediaViewerModal).
+            //
+            // iOS + web: do NOT wrap in Modal. On iOS a second Modal is a separate UIWindow — it
+            // captures all touches until dismissed, even with pointerEvents="none", so the app
+            // feels frozen while the toast is visible. Inline toast in the root view + zIndex
+            // keeps touches passing through to the chat below.
+            if (Platform.OS === 'android') {
               return (
                 <Modal
                   visible

--- a/frontend/src/features/chat/components/GroupMembersModal.tsx
+++ b/frontend/src/features/chat/components/GroupMembersModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { TextInput } from 'react-native';
-import { Modal, Platform, Pressable, ScrollView, Text, View } from 'react-native';
+import { Modal, Platform, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { AppTextInput } from '../../../components/AppTextInput';
 import { GroupMembersSectionList } from '../../../components/GroupMembersSectionList';
@@ -72,6 +72,117 @@ export function GroupMembersModal({
       ),
     [kb.keyboardVisible, kb.remainingOverlap, kb.windowHeight, sheetHeight],
   );
+
+  if (Platform.OS === 'ios') {
+    if (!visible) return <></>;
+    return (
+      <View style={[StyleSheet.absoluteFillObject, { zIndex: 10000 }]}>
+        <View style={[styles.modalOverlay, bottomPad > 0 ? { paddingBottom: bottomPad } : null]}>
+          <View
+            style={[
+              styles.summaryModal,
+              isDark ? styles.summaryModalDark : null,
+              kb.keyboardVisible
+                ? { maxHeight: kb.availableHeightAboveKeyboard, minHeight: 0 }
+                : null,
+            ]}
+            onLayout={(e) => {
+              const h = e?.nativeEvent?.layout?.height;
+              if (typeof h === 'number' && Number.isFinite(h) && h > 0) setSheetHeight(h);
+            }}
+          >
+            {/* existing content below remains unchanged */}
+            <Text style={[styles.summaryTitle, isDark ? styles.summaryTitleDark : null]}>
+              Members
+            </Text>
+
+            {meIsAdmin ? (
+              <View style={{ marginTop: 10 }}>
+                <AppTextInput
+                  isDark={isDark}
+                  ref={(r) => {
+                    addMembersInputRef.current = r;
+                  }}
+                  value={addMembersDraft}
+                  onChangeText={onChangeAddMembersDraft}
+                  onSubmitEditing={() => {
+                    if (busy) return;
+                    void Promise.resolve(onAddMembers());
+                  }}
+                  placeholder="Add usernames (comma/space separated)"
+                  style={{
+                    width: '100%',
+                    height: 48,
+                    paddingHorizontal: 12,
+                    borderWidth: 1,
+                    borderRadius: 10,
+                    backgroundColor: isDark
+                      ? APP_COLORS.dark.bg.header
+                      : APP_COLORS.light.bg.surface2,
+                    borderColor: isDark
+                      ? APP_COLORS.dark.border.default
+                      : APP_COLORS.light.border.subtle,
+                    color: isDark ? APP_COLORS.dark.text.primary : APP_COLORS.light.text.primary,
+                    fontSize: 16,
+                  }}
+                  editable
+                  returnKeyType="done"
+                />
+                <View style={[styles.summaryButtons, { justifyContent: 'flex-end' }]}>
+                  <Pressable
+                    style={[
+                      styles.toolBtn,
+                      isDark ? styles.toolBtnDark : null,
+                      busy ? { opacity: 0.6 } : null,
+                    ]}
+                    disabled={busy}
+                    onPress={() => void Promise.resolve(onAddMembers())}
+                  >
+                    <Text style={[styles.toolBtnText, isDark ? styles.toolBtnTextDark : null]}>
+                      Add
+                    </Text>
+                  </Pressable>
+                </View>
+              </View>
+            ) : null}
+
+            <ScrollView
+              style={{ marginTop: 0, maxHeight: 360 }}
+              contentContainerStyle={{ paddingTop: 0 }}
+              keyboardShouldPersistTaps="handled"
+            >
+              <GroupMembersSectionList
+                members={members}
+                mySub={mySub}
+                isDark={!!isDark}
+                styles={styles}
+                meIsAdmin={!!meIsAdmin}
+                groupActionBusy={!!busy}
+                kickCooldownUntilBySub={kickCooldownUntilBySub}
+                avatarUrlByPath={avatarUrlByPath}
+                onKick={onKick}
+                onUnban={onUnban}
+                onToggleAdmin={onToggleAdmin}
+                onBan={onBan}
+              />
+            </ScrollView>
+
+            <View style={styles.summaryButtons}>
+              <Pressable
+                style={[styles.toolBtn, isDark ? styles.summaryModalDark : null]}
+                onPress={onClose}
+              >
+                <Text style={[styles.toolBtnText, isDark ? styles.toolBtnTextDark : null]}>
+                  Close
+                </Text>
+              </Pressable>
+            </View>
+          </View>
+        </View>
+      </View>
+    );
+  }
+
   return (
     <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
       <View

--- a/frontend/src/features/chat/components/MessageActionMenuModal.tsx
+++ b/frontend/src/features/chat/components/MessageActionMenuModal.tsx
@@ -171,804 +171,768 @@ export function MessageActionMenuModal({
     return target ? getCopyableMessageText({ msg: target, isDm }) : null;
   }, [isDm, target]);
 
-  return (
-    <Modal visible={visible} transparent animationType="fade">
-      <View style={styles.actionMenuOverlay}>
-        <Pressable style={StyleSheet.absoluteFill} onPress={close} />
-        <Animated.View
-          style={[
-            styles.actionMenuCard,
-            isDark ? styles.actionMenuCardDark : null,
-            (() => {
-              type VisualViewportLike = { width?: number; height?: number };
-              const vv =
-                Platform.OS === 'web' && typeof window !== 'undefined' && 'visualViewport' in window
-                  ? ((window as { visualViewport?: VisualViewportLike }).visualViewport ?? null)
-                  : null;
-              // On web, prefer the *visual viewport* (handles mobile browser toolbars/URL bar correctly).
-              const w =
-                (vv && typeof vv.width === 'number' ? vv.width : null) ??
-                Dimensions.get('window').width;
-              const h =
-                (vv && typeof vv.height === 'number' ? vv.height : null) ??
-                Dimensions.get('window').height;
-              const cardW = Math.min(w - 36, 360);
-              const left = Math.max(18, (w - cardW) / 2);
-              const anchorY = anchor?.y ?? h / 2;
-              const safeTop = Math.max(12, 12 + (insets.top || 0));
-              // Web often reports 0 bottom insets; keep a comfortable bottom margin anyway.
-              const safeBottom = Math.max(
-                12,
-                12 + (insets.bottom || 0) + (Platform.OS === 'web' ? 16 : 0),
-              );
-              // Reposition-only (no scrolling): clamp the card so it stays fully visible.
-              // Use a best-effort measured height when available, otherwise fall back to a conservative estimate.
-              const cardH = Math.max(220, Math.floor(measuredH || measuredHRef.current || 360));
-              const desiredTop = anchorY - 160;
-              const minTop = safeTop;
-              const maxTop = Math.max(minTop, Math.floor(h - safeBottom - cardH));
-              const top = Math.max(minTop, Math.min(maxTop, desiredTop));
-              const maxH = Math.max(220, Math.floor(h - safeTop - safeBottom));
-              return { position: 'absolute', width: cardW, left, top, maxHeight: maxH };
-            })(),
+  // On iOS render as View overlay so UiPromptModal (delete confirm etc.) can show without stacking modals.
+  const card = (
+    <Animated.View
+      style={[
+        styles.actionMenuCard,
+        isDark ? styles.actionMenuCardDark : null,
+        (() => {
+          type VisualViewportLike = { width?: number; height?: number };
+          const vv =
+            Platform.OS === 'web' && typeof window !== 'undefined' && 'visualViewport' in window
+              ? ((window as { visualViewport?: VisualViewportLike }).visualViewport ?? null)
+              : null;
+          // On web, prefer the *visual viewport* (handles mobile browser toolbars/URL bar correctly).
+          const w =
+            (vv && typeof vv.width === 'number' ? vv.width : null) ??
+            Dimensions.get('window').width;
+          const h =
+            (vv && typeof vv.height === 'number' ? vv.height : null) ??
+            Dimensions.get('window').height;
+          const cardW = Math.min(w - 36, 360);
+          const left = Math.max(18, (w - cardW) / 2);
+          const anchorY = anchor?.y ?? h / 2;
+          const safeTop = Math.max(12, 12 + (insets.top || 0));
+          // Web often reports 0 bottom insets; keep a comfortable bottom margin anyway.
+          // On iOS, add a bit more so the card doesn't sit flush with the bottom edge.
+          const iosExtraBottom = Platform.OS === 'ios' ? 24 : 0;
+          const safeBottom = Math.max(
+            12,
+            12 + (insets.bottom || 0) + (Platform.OS === 'web' ? 16 : 0) + iosExtraBottom,
+          );
+          // Reposition-only (no scrolling): clamp the card so it stays fully visible.
+          // Use a best-effort measured height when available, otherwise fall back to a conservative estimate.
+          const cardH = Math.max(220, Math.floor(measuredH || measuredHRef.current || 360));
+          const desiredTop = anchorY - 160;
+          const minTop = safeTop;
+          const maxTop = Math.max(minTop, Math.floor(h - safeBottom - cardH));
+          const top = Math.max(minTop, Math.min(maxTop, desiredTop));
+          const maxH = Math.max(220, Math.floor(h - safeTop - safeBottom));
+          return { position: 'absolute', width: cardW, left, top, maxHeight: maxH };
+        })(),
+        {
+          opacity: anim,
+          transform: [
             {
-              opacity: anim,
-              transform: [
-                {
-                  scale: anim.interpolate({
-                    inputRange: [0, 1],
-                    outputRange: [0.98, 1],
-                  }),
-                },
-                {
-                  translateY: anim.interpolate({
-                    inputRange: [0, 1],
-                    outputRange: [
-                      (anchor?.y ?? 0) > Dimensions.get('window').height / 2 ? 10 : -10,
-                      0,
-                    ],
-                  }),
-                },
-              ],
+              scale: anim.interpolate({
+                inputRange: [0, 1],
+                outputRange: [0.98, 1],
+              }),
             },
-          ]}
-          onLayout={(e) => {
-            try {
-              const h = Number(e?.nativeEvent?.layout?.height ?? 0);
-              if (Number.isFinite(h) && h > 0) onMeasuredH(h);
-            } catch {
-              // ignore
-            }
-          }}
+            {
+              translateY: anim.interpolate({
+                inputRange: [0, 1],
+                outputRange: [(anchor?.y ?? 0) > Dimensions.get('window').height / 2 ? 10 : -10, 0],
+              }),
+            },
+          ],
+        },
+      ]}
+      onLayout={(e) => {
+        try {
+          const h = Number(e?.nativeEvent?.layout?.height ?? 0);
+          if (Number.isFinite(h) && h > 0) onMeasuredH(h);
+        } catch {
+          // ignore
+        }
+      }}
+    >
+      {/* Message preview (Signal-style) */}
+      {target ? (
+        <View
+          style={[styles.actionMenuPreviewRow, isDark ? styles.actionMenuPreviewRowDark : null]}
         >
-          {/* Message preview (Signal-style) */}
-          {target ? (
-            <View
-              style={[styles.actionMenuPreviewRow, isDark ? styles.actionMenuPreviewRowDark : null]}
-            >
-              {(() => {
-                const t = target;
-                const isOutgoingByUserSub =
-                  !!myUserId && !!t.userSub && String(t.userSub) === String(myUserId);
-                const isEncryptedOutgoing =
-                  !!t.encrypted && !!myPublicKey && t.encrypted.senderPublicKey === myPublicKey;
-                const isPlainOutgoing =
-                  !t.encrypted &&
-                  (isOutgoingByUserSub
-                    ? true
-                    : normalizeUser(t.userLower ?? t.user ?? 'anon') ===
-                      normalizeUser(displayName));
-                const isOutgoing = isOutgoingByUserSub || isEncryptedOutgoing || isPlainOutgoing;
-                const bubbleStyle = isOutgoing
-                  ? styles.messageBubbleOutgoing
-                  : isDark
-                    ? styles.messageBubbleIncomingDark
-                    : styles.messageBubbleIncoming;
-                const textStyle = isOutgoing
-                  ? styles.messageTextOutgoing
-                  : isDark
-                    ? styles.messageTextIncomingDark
-                    : styles.messageTextIncoming;
-                if (t.deletedAt) {
-                  return (
-                    <View style={[styles.messageBubble, bubbleStyle]}>
-                      <Text style={[styles.messageText, textStyle]}>
-                        This message has been deleted
-                      </Text>
-                    </View>
-                  );
-                }
+          {(() => {
+            const t = target;
+            const isOutgoingByUserSub =
+              !!myUserId && !!t.userSub && String(t.userSub) === String(myUserId);
+            const isEncryptedOutgoing =
+              !!t.encrypted && !!myPublicKey && t.encrypted.senderPublicKey === myPublicKey;
+            const isPlainOutgoing =
+              !t.encrypted &&
+              (isOutgoingByUserSub
+                ? true
+                : normalizeUser(t.userLower ?? t.user ?? 'anon') === normalizeUser(displayName));
+            const isOutgoing = isOutgoingByUserSub || isEncryptedOutgoing || isPlainOutgoing;
+            const bubbleStyle = isOutgoing
+              ? styles.messageBubbleOutgoing
+              : isDark
+                ? styles.messageBubbleIncomingDark
+                : styles.messageBubbleIncoming;
+            const textStyle = isOutgoing
+              ? styles.messageTextOutgoing
+              : isDark
+                ? styles.messageTextIncomingDark
+                : styles.messageTextIncoming;
+            if (t.deletedAt) {
+              return (
+                <View style={[styles.messageBubble, bubbleStyle]}>
+                  <Text style={[styles.messageText, textStyle]}>This message has been deleted</Text>
+                </View>
+              );
+            }
 
-                let caption = '';
-                let thumbUri: string | null = null;
-                let kind: 'image' | 'video' | 'file' | null = null;
-                let fileName: string | undefined;
-                let contentType: string | undefined;
-                let hasMedia = false;
-                let mediaCount = 0;
+            let caption = '';
+            let thumbUri: string | null = null;
+            let kind: 'image' | 'video' | 'file' | null = null;
+            let fileName: string | undefined;
+            let contentType: string | undefined;
+            let hasMedia = false;
+            let mediaCount = 0;
 
-                if (t.encrypted || t.groupEncrypted) {
-                  if (!t.decryptedText) {
-                    return (
-                      <View style={[styles.messageBubble, bubbleStyle]}>
-                        <Text style={[styles.messageText, textStyle]}>{encryptedPlaceholder}</Text>
-                      </View>
-                    );
-                  }
-                  const plain = String(t.decryptedText || '');
-                  const encText = parseEncryptedTextEnvelope(plain);
-                  const dmEnv = parseDmMediaEnvelope(plain);
-                  const dmItems = dmEnv ? normalizeDmMediaItems(dmEnv) : [];
-                  const gEnv = parseGroupMediaEnvelope(plain);
-                  const gItems = gEnv ? normalizeGroupMediaItems(gEnv) : [];
-                  if (dmItems.length || gItems.length) {
-                    hasMedia = true;
-                    mediaCount = dmItems.length || gItems.length || 0;
-                    caption = String((dmEnv?.caption ?? gEnv?.caption) || '');
-                    const first = dmItems[0]?.media ?? gItems[0]?.media;
-                    const firstRec =
-                      typeof first === 'object' && first != null
-                        ? (first as Record<string, unknown>)
-                        : null;
-                    const k = firstRec && typeof firstRec.kind === 'string' ? firstRec.kind : null;
-                    kind = k === 'image' || k === 'video' ? k : 'file';
-                    fileName =
-                      firstRec && typeof firstRec.fileName === 'string'
-                        ? String(firstRec.fileName)
-                        : undefined;
-                    contentType =
-                      firstRec && typeof firstRec.contentType === 'string'
-                        ? String(firstRec.contentType)
-                        : undefined;
-                    // Reuse decrypted thumb cache so message options show actual previews.
-                    const thumbKey =
-                      firstRec &&
-                      (typeof firstRec.thumbPath === 'string' ||
-                        typeof firstRec.thumbPath === 'number')
-                        ? String(firstRec.thumbPath)
-                        : null;
-                    if (kind !== 'file' && thumbKey && dmThumbUriByPath[thumbKey]) {
-                      thumbUri = dmThumbUriByPath[thumbKey];
-                    } else {
-                      thumbUri = null;
-                    }
-                  } else {
-                    caption = encText ? String(encText.text || '') : plain;
-                  }
+            if (t.encrypted || t.groupEncrypted) {
+              if (!t.decryptedText) {
+                return (
+                  <View style={[styles.messageBubble, bubbleStyle]}>
+                    <Text style={[styles.messageText, textStyle]}>{encryptedPlaceholder}</Text>
+                  </View>
+                );
+              }
+              const plain = String(t.decryptedText || '');
+              const encText = parseEncryptedTextEnvelope(plain);
+              const dmEnv = parseDmMediaEnvelope(plain);
+              const dmItems = dmEnv ? normalizeDmMediaItems(dmEnv) : [];
+              const gEnv = parseGroupMediaEnvelope(plain);
+              const gItems = gEnv ? normalizeGroupMediaItems(gEnv) : [];
+              if (dmItems.length || gItems.length) {
+                hasMedia = true;
+                mediaCount = dmItems.length || gItems.length || 0;
+                caption = String((dmEnv?.caption ?? gEnv?.caption) || '');
+                const first = dmItems[0]?.media ?? gItems[0]?.media;
+                const firstRec =
+                  typeof first === 'object' && first != null
+                    ? (first as Record<string, unknown>)
+                    : null;
+                const k = firstRec && typeof firstRec.kind === 'string' ? firstRec.kind : null;
+                kind = k === 'image' || k === 'video' ? k : 'file';
+                fileName =
+                  firstRec && typeof firstRec.fileName === 'string'
+                    ? String(firstRec.fileName)
+                    : undefined;
+                contentType =
+                  firstRec && typeof firstRec.contentType === 'string'
+                    ? String(firstRec.contentType)
+                    : undefined;
+                // Reuse decrypted thumb cache so message options show actual previews.
+                const thumbKey =
+                  firstRec &&
+                  (typeof firstRec.thumbPath === 'string' || typeof firstRec.thumbPath === 'number')
+                    ? String(firstRec.thumbPath)
+                    : null;
+                if (kind !== 'file' && thumbKey && dmThumbUriByPath[thumbKey]) {
+                  thumbUri = dmThumbUriByPath[thumbKey];
                 } else {
-                  const raw = String(t.rawText ?? t.text ?? '');
-                  const env = !isDm ? parseChatEnvelope(raw) : null;
-                  const envList = env ? normalizeChatMediaList(env.media) : [];
-                  if (envList.length) {
-                    hasMedia = true;
-                    mediaCount = envList.length || 0;
-                    caption = String(env?.text || '');
-                    const first = envList[0];
-                    kind = first.kind === 'image' || first.kind === 'video' ? first.kind : 'file';
-                    fileName =
-                      typeof first.fileName === 'string' ? String(first.fileName) : undefined;
-                    contentType =
-                      typeof first.contentType === 'string' ? String(first.contentType) : undefined;
-                    const key = String(first.thumbPath || first.path);
-                    // Only show a thumbnail for actual images/videos.
-                    thumbUri = kind !== 'file' && mediaUrlByPath[key] ? mediaUrlByPath[key] : null;
-                  } else {
-                    caption = raw;
-                  }
+                  thumbUri = null;
                 }
+              } else {
+                caption = encText ? String(encText.text || '') : plain;
+              }
+            } else {
+              const raw = String(t.rawText ?? t.text ?? '');
+              const env = !isDm ? parseChatEnvelope(raw) : null;
+              const envList = env ? normalizeChatMediaList(env.media) : [];
+              if (envList.length) {
+                hasMedia = true;
+                mediaCount = envList.length || 0;
+                caption = String(env?.text || '');
+                const first = envList[0];
+                kind = first.kind === 'image' || first.kind === 'video' ? first.kind : 'file';
+                fileName = typeof first.fileName === 'string' ? String(first.fileName) : undefined;
+                contentType =
+                  typeof first.contentType === 'string' ? String(first.contentType) : undefined;
+                const key = String(first.thumbPath || first.path);
+                // Only show a thumbnail for actual images/videos.
+                thumbUri = kind !== 'file' && mediaUrlByPath[key] ? mediaUrlByPath[key] : null;
+              } else {
+                caption = raw;
+              }
+            }
 
-                if (!hasMedia) {
-                  const showReply =
-                    !t.deletedAt &&
-                    !!t.replyToMessageId &&
-                    String(t.replyToPreview || '').trim().length > 0;
-                  const replyKind =
-                    t.replyToMediaKind === 'image' ||
-                    t.replyToMediaKind === 'video' ||
-                    t.replyToMediaKind === 'file'
-                      ? t.replyToMediaKind
-                      : null;
-                  const replyCount =
-                    typeof t.replyToMediaCount === 'number' && Number.isFinite(t.replyToMediaCount)
-                      ? Math.max(0, Math.floor(t.replyToMediaCount))
-                      : 0;
-                  const replyLabel = (() => {
-                    const origin =
-                      t.replyToMessageId && messageListData && messageListData.length
-                        ? messageListData.find((m) => m && m.id === t.replyToMessageId)
-                        : null;
-                    const sub =
-                      (typeof t.replyToUserSub === 'string' ? t.replyToUserSub : '') ||
-                      (origin?.userSub ? String(origin.userSub) : '');
-                    const replyingToMe = !!sub && !!myUserId && String(sub) === String(myUserId);
-                    if (replyingToMe) return isOutgoing ? 'yourself' : 'You';
-                    const fromMaps = sub ? nameBySub[String(sub)] : '';
-                    if (fromMaps) return fromMaps;
-                    const fromOrigin = origin?.user ? String(origin.user).trim() : '';
-                    if (fromOrigin) return fromOrigin;
-                    if (sub) return `User ${String(sub).slice(0, 6)}`;
-                    return 'Unknown user';
-                  })();
+            if (!hasMedia) {
+              const showReply =
+                !t.deletedAt &&
+                !!t.replyToMessageId &&
+                String(t.replyToPreview || '').trim().length > 0;
+              const replyKind =
+                t.replyToMediaKind === 'image' ||
+                t.replyToMediaKind === 'video' ||
+                t.replyToMediaKind === 'file'
+                  ? t.replyToMediaKind
+                  : null;
+              const replyCount =
+                typeof t.replyToMediaCount === 'number' && Number.isFinite(t.replyToMediaCount)
+                  ? Math.max(0, Math.floor(t.replyToMediaCount))
+                  : 0;
+              const replyLabel = (() => {
+                const origin =
+                  t.replyToMessageId && messageListData && messageListData.length
+                    ? messageListData.find((m) => m && m.id === t.replyToMessageId)
+                    : null;
+                const sub =
+                  (typeof t.replyToUserSub === 'string' ? t.replyToUserSub : '') ||
+                  (origin?.userSub ? String(origin.userSub) : '');
+                const replyingToMe = !!sub && !!myUserId && String(sub) === String(myUserId);
+                if (replyingToMe) return isOutgoing ? 'yourself' : 'You';
+                const fromMaps = sub ? nameBySub[String(sub)] : '';
+                if (fromMaps) return fromMaps;
+                const fromOrigin = origin?.user ? String(origin.user).trim() : '';
+                if (fromOrigin) return fromOrigin;
+                if (sub) return `User ${String(sub).slice(0, 6)}`;
+                return 'Unknown user';
+              })();
 
-                  return (
-                    <View style={[styles.messageBubble, bubbleStyle]}>
-                      {showReply ? (
+              return (
+                <View style={[styles.messageBubble, bubbleStyle]}>
+                  {showReply ? (
+                    <View
+                      style={[
+                        styles.replySnippet,
+                        { flexDirection: 'row', gap: 10, marginTop: 0 },
+                        isOutgoing
+                          ? styles.replySnippetOutgoing
+                          : isDark
+                            ? styles.replySnippetIncomingDark
+                            : styles.replySnippetIncoming,
+                      ]}
+                    >
+                      {replyKind ? (
                         <View
                           style={[
-                            styles.replySnippet,
-                            { flexDirection: 'row', gap: 10, marginTop: 0 },
-                            isOutgoing
-                              ? styles.replySnippetOutgoing
-                              : isDark
-                                ? styles.replySnippetIncomingDark
-                                : styles.replySnippetIncoming,
+                            styles.replyThumbWrap,
+                            { marginBottom: 0, marginRight: 0, alignSelf: 'center' },
                           ]}
                         >
-                          {replyKind ? (
-                            <View
-                              style={[
-                                styles.replyThumbWrap,
-                                { marginBottom: 0, marginRight: 0, alignSelf: 'center' },
-                              ]}
-                            >
-                              {replyKind === 'file' ? (
-                                <View style={[styles.replyThumb, styles.replyThumbPlaceholder]}>
-                                  <MaterialCommunityIcons
-                                    name={
-                                      (fileIconNameForMedia({
+                          {replyKind === 'file' ? (
+                            <View style={[styles.replyThumb, styles.replyThumbPlaceholder]}>
+                              <MaterialCommunityIcons
+                                name={
+                                  (fileIconNameForMedia({
+                                    kind: 'file',
+                                    contentType: t.replyToMediaContentType,
+                                    fileName: t.replyToMediaFileName,
+                                  }) || 'file-outline') as never
+                                }
+                                size={24}
+                                color={
+                                  isOutgoing
+                                    ? withAlpha(PALETTE.white, 0.92)
+                                    : fileBrandColorForMedia({
                                         kind: 'file',
                                         contentType: t.replyToMediaContentType,
                                         fileName: t.replyToMediaFileName,
-                                      }) || 'file-outline') as never
-                                    }
-                                    size={24}
-                                    color={
-                                      isOutgoing
-                                        ? withAlpha(PALETTE.white, 0.92)
-                                        : fileBrandColorForMedia({
-                                            kind: 'file',
-                                            contentType: t.replyToMediaContentType,
-                                            fileName: t.replyToMediaFileName,
-                                          }) ||
-                                          (isDark
-                                            ? styles.replySnippetLabelIncomingDark?.color
-                                            : styles.replySnippetLabelIncoming?.color)
-                                    }
-                                  />
-                                </View>
-                              ) : (
-                                <View style={[styles.replyThumb, styles.replyThumbPlaceholder]}>
-                                  <Text style={styles.replyThumbPlaceholderText}>
-                                    {replyKind === 'image' ? 'Photo' : 'Video'}
-                                  </Text>
-                                </View>
-                              )}
-                              {replyCount > 1 ? (
-                                <View style={styles.replyThumbCountBadge}>
-                                  <Text
-                                    style={styles.replyThumbCountText}
-                                  >{`+${replyCount - 1}`}</Text>
-                                </View>
-                              ) : null}
+                                      }) ||
+                                      (isDark
+                                        ? styles.replySnippetLabelIncomingDark?.color
+                                        : styles.replySnippetLabelIncoming?.color)
+                                }
+                              />
+                            </View>
+                          ) : (
+                            <View style={[styles.replyThumb, styles.replyThumbPlaceholder]}>
+                              <Text style={styles.replyThumbPlaceholderText}>
+                                {replyKind === 'image' ? 'Photo' : 'Video'}
+                              </Text>
+                            </View>
+                          )}
+                          {replyCount > 1 ? (
+                            <View style={styles.replyThumbCountBadge}>
+                              <Text style={styles.replyThumbCountText}>{`+${replyCount - 1}`}</Text>
                             </View>
                           ) : null}
-
-                          <View style={{ flex: 1, minWidth: 0 }}>
-                            <Text
-                              style={[
-                                styles.replySnippetLabel,
-                                isOutgoing
-                                  ? styles.replySnippetLabelOutgoing
-                                  : isDark
-                                    ? styles.replySnippetLabelIncomingDark
-                                    : styles.replySnippetLabelIncoming,
-                              ]}
-                              numberOfLines={1}
-                            >
-                              {`Replying to ${replyLabel}`}
-                            </Text>
-                            <Text
-                              style={[
-                                styles.replySnippetText,
-                                isOutgoing
-                                  ? styles.replySnippetTextOutgoing
-                                  : isDark
-                                    ? styles.replySnippetTextIncomingDark
-                                    : styles.replySnippetTextIncoming,
-                              ]}
-                              numberOfLines={2}
-                            >
-                              {String(t.replyToPreview || '').trim()}
-                            </Text>
-                          </View>
                         </View>
                       ) : null}
 
-                      <RichText
-                        text={String(caption || '')}
-                        isDark={isDark}
-                        enableMentions={!isDm}
-                        variant={isOutgoing ? 'outgoing' : 'incoming'}
-                        style={[styles.messageText, textStyle]}
-                      />
+                      <View style={{ flex: 1, minWidth: 0 }}>
+                        <Text
+                          style={[
+                            styles.replySnippetLabel,
+                            isOutgoing
+                              ? styles.replySnippetLabelOutgoing
+                              : isDark
+                                ? styles.replySnippetLabelIncomingDark
+                                : styles.replySnippetLabelIncoming,
+                          ]}
+                          numberOfLines={1}
+                        >
+                          {`Replying to ${replyLabel}`}
+                        </Text>
+                        <Text
+                          style={[
+                            styles.replySnippetText,
+                            isOutgoing
+                              ? styles.replySnippetTextOutgoing
+                              : isDark
+                                ? styles.replySnippetTextIncomingDark
+                                : styles.replySnippetTextIncoming,
+                          ]}
+                          numberOfLines={2}
+                        >
+                          {String(t.replyToPreview || '').trim()}
+                        </Text>
+                      </View>
                     </View>
-                  );
-                }
+                  ) : null}
 
-                const label = attachmentLabelForMedia({
-                  kind: kind === 'image' || kind === 'video' ? kind : 'file',
-                  contentType,
-                  fileName,
-                });
-                const multiLabel = mediaCount > 1 ? `${label} · ${mediaCount} attachments` : label;
-                const isFile = kind === 'file';
-                const displayFileName = String(fileName || '').trim() || label;
-                const fileIconName = fileIconNameForMedia({
-                  kind: 'file',
-                  contentType,
-                  fileName,
-                });
-                const fileBadge = fileBadgeForMedia({ kind: 'file', contentType, fileName });
-                const fileColor =
-                  fileBrandColorForMedia({ kind: 'file', contentType, fileName }) ||
-                  (isDark ? styles.actionMenuMediaMetaDark?.color : undefined);
-                return (
-                  <View style={styles.actionMenuMediaPreview}>
-                    {isFile ? (
-                      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
-                        <View style={styles.actionMenuMediaThumbWrap}>
-                          {fileIconName ? (
-                            <MaterialCommunityIcons
-                              name={fileIconName as never}
-                              size={36}
-                              color={
-                                fileColor ||
-                                (isDark
-                                  ? styles.actionMenuMediaMetaDark?.color
-                                  : styles.actionMenuMediaMeta?.color)
-                              }
-                            />
-                          ) : (
-                            <Text
-                              style={[
-                                styles.actionMenuMediaThumbPlaceholderText,
-                                {
-                                  paddingHorizontal: 10,
-                                  paddingVertical: 6,
-                                  borderRadius: 999,
-                                  backgroundColor: 'transparent',
-                                },
-                              ]}
-                            >
-                              {fileBadge}
-                            </Text>
-                          )}
-                        </View>
-                        <View style={{ flex: 1, minWidth: 0 }}>
-                          <Text
-                            style={[
-                              styles.actionMenuMediaCaption,
-                              isDark ? styles.actionMenuMediaCaptionDark : null,
-                              { fontWeight: '800' },
-                            ]}
-                            numberOfLines={1}
-                            ellipsizeMode="middle"
-                          >
-                            {displayFileName}
-                          </Text>
-                          <Text
-                            style={[
-                              styles.actionMenuMediaMeta,
-                              isDark ? styles.actionMenuMediaMetaDark : null,
-                            ]}
-                            numberOfLines={1}
-                          >
-                            {multiLabel}
-                          </Text>
-                        </View>
-                      </View>
-                    ) : (
-                      <View style={styles.actionMenuMediaThumbWrap}>
-                        {thumbUri ? (
-                          <Image
-                            source={{ uri: thumbUri }}
-                            style={styles.actionMenuMediaThumb}
-                            resizeMode="cover"
-                          />
-                        ) : (
-                          <View style={styles.actionMenuMediaThumbPlaceholder}>
-                            <Text style={styles.actionMenuMediaThumbPlaceholderText}>{label}</Text>
-                          </View>
-                        )}
-                      </View>
-                    )}
-                    {!isFile ? (
+                  <RichText
+                    text={String(caption || '')}
+                    isDark={isDark}
+                    enableMentions={!isDm}
+                    variant={isOutgoing ? 'outgoing' : 'incoming'}
+                    style={[styles.messageText, textStyle]}
+                  />
+                </View>
+              );
+            }
+
+            const label = attachmentLabelForMedia({
+              kind: kind === 'image' || kind === 'video' ? kind : 'file',
+              contentType,
+              fileName,
+            });
+            const multiLabel = mediaCount > 1 ? `${label} · ${mediaCount} attachments` : label;
+            const isFile = kind === 'file';
+            const displayFileName = String(fileName || '').trim() || label;
+            const fileIconName = fileIconNameForMedia({
+              kind: 'file',
+              contentType,
+              fileName,
+            });
+            const fileBadge = fileBadgeForMedia({ kind: 'file', contentType, fileName });
+            const fileColor =
+              fileBrandColorForMedia({ kind: 'file', contentType, fileName }) ||
+              (isDark ? styles.actionMenuMediaMetaDark?.color : undefined);
+            return (
+              <View style={styles.actionMenuMediaPreview}>
+                {isFile ? (
+                  <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+                    <View style={styles.actionMenuMediaThumbWrap}>
+                      {fileIconName ? (
+                        <MaterialCommunityIcons
+                          name={fileIconName as never}
+                          size={36}
+                          color={
+                            fileColor ||
+                            (isDark
+                              ? styles.actionMenuMediaMetaDark?.color
+                              : styles.actionMenuMediaMeta?.color)
+                          }
+                        />
+                      ) : (
+                        <Text
+                          style={[
+                            styles.actionMenuMediaThumbPlaceholderText,
+                            {
+                              paddingHorizontal: 10,
+                              paddingVertical: 6,
+                              borderRadius: 999,
+                              backgroundColor: 'transparent',
+                            },
+                          ]}
+                        >
+                          {fileBadge}
+                        </Text>
+                      )}
+                    </View>
+                    <View style={{ flex: 1, minWidth: 0 }}>
+                      <Text
+                        style={[
+                          styles.actionMenuMediaCaption,
+                          isDark ? styles.actionMenuMediaCaptionDark : null,
+                          { fontWeight: '800' },
+                        ]}
+                        numberOfLines={1}
+                        ellipsizeMode="middle"
+                      >
+                        {displayFileName}
+                      </Text>
                       <Text
                         style={[
                           styles.actionMenuMediaMeta,
                           isDark ? styles.actionMenuMediaMetaDark : null,
                         ]}
+                        numberOfLines={1}
                       >
                         {multiLabel}
                       </Text>
-                    ) : null}
-                    {caption.trim().length ? (
-                      <RichText
-                        text={caption.trim()}
-                        isDark={isDark}
-                        enableMentions={!isDm}
-                        variant={isOutgoing ? 'outgoing' : 'incoming'}
-                        style={[
-                          styles.actionMenuMediaCaption,
-                          isDark ? styles.actionMenuMediaCaptionDark : null,
-                        ]}
-                      />
-                    ) : null}
+                    </View>
                   </View>
-                );
-              })()}
-            </View>
-          ) : null}
-
-          <ScrollView
-            style={styles.actionMenuOptionsScroll}
-            contentContainerStyle={styles.actionMenuOptionsContent}
-            showsVerticalScrollIndicator
-            keyboardShouldPersistTaps="handled"
-          >
-            {/* Reactions */}
-            {target && !target.deletedAt && (!target.encrypted || !!target.decryptedText) ? (
-              <View style={styles.reactionQuickRow}>
-                <ScrollView
-                  horizontal
-                  showsHorizontalScrollIndicator={false}
-                  contentContainerStyle={styles.reactionQuickScrollContent}
-                >
-                  {quickReactions.map((emoji) => {
-                    const mine = myUserId
-                      ? (target.reactions?.[emoji]?.userSubs || []).includes(myUserId)
-                      : false;
-                    return (
-                      <Pressable
-                        key={`quick:${emoji}`}
-                        onPress={() => {
-                          sendReaction(target, emoji);
-                          close();
-                        }}
-                        style={({ pressed }) => [
-                          styles.reactionQuickBtn,
-                          isDark ? styles.reactionQuickBtnDark : null,
-                          mine
-                            ? isDark
-                              ? styles.reactionQuickBtnMineDark
-                              : styles.reactionQuickBtnMine
-                            : null,
-                          pressed ? { opacity: 0.85 } : null,
-                        ]}
-                        accessibilityRole="button"
-                        accessibilityLabel={`React ${emoji}`}
-                      >
-                        <Text style={styles.reactionQuickEmoji}>{emoji}</Text>
-                      </Pressable>
-                    );
-                  })}
-                </ScrollView>
-
-                <Pressable
-                  onPress={() => {
-                    openReactionPicker(target);
-                    close();
-                  }}
-                  style={({ pressed }) => [
-                    styles.reactionQuickMore,
-                    isDark ? styles.reactionQuickMoreDark : null,
-                    pressed ? { opacity: 0.85 } : null,
-                  ]}
-                  accessibilityRole="button"
-                  accessibilityLabel="More reactions"
-                >
+                ) : (
+                  <View style={styles.actionMenuMediaThumbWrap}>
+                    {thumbUri ? (
+                      <Image
+                        source={{ uri: thumbUri }}
+                        style={styles.actionMenuMediaThumb}
+                        resizeMode="cover"
+                      />
+                    ) : (
+                      <View style={styles.actionMenuMediaThumbPlaceholder}>
+                        <Text style={styles.actionMenuMediaThumbPlaceholderText}>{label}</Text>
+                      </View>
+                    )}
+                  </View>
+                )}
+                {!isFile ? (
                   <Text
                     style={[
-                      styles.reactionQuickMoreText,
-                      isDark ? styles.reactionQuickMoreTextDark : null,
+                      styles.actionMenuMediaMeta,
+                      isDark ? styles.actionMenuMediaMetaDark : null,
                     ]}
                   >
-                    …
+                    {multiLabel}
                   </Text>
-                </Pressable>
+                ) : null}
+                {caption.trim().length ? (
+                  <RichText
+                    text={caption.trim()}
+                    isDark={isDark}
+                    enableMentions={!isDm}
+                    variant={isOutgoing ? 'outgoing' : 'incoming'}
+                    style={[
+                      styles.actionMenuMediaCaption,
+                      isDark ? styles.actionMenuMediaCaptionDark : null,
+                    ]}
+                  />
+                ) : null}
               </View>
-            ) : null}
+            );
+          })()}
+        </View>
+      ) : null}
 
-            {target?.encrypted || target?.groupEncrypted ? (
-              <Pressable
-                onPress={() => {
-                  setCipherText(String(target?.rawText ?? target?.text ?? ''));
-                  setCipherOpen(true);
-                  close();
-                }}
-                style={({ pressed }) => [
-                  styles.actionMenuRow,
-                  pressed ? styles.actionMenuRowPressed : null,
-                ]}
-              >
-                <Text style={[styles.actionMenuText, isDark ? styles.actionMenuTextDark : null]}>
-                  View Ciphertext
-                </Text>
-              </Pressable>
-            ) : null}
-
-            {target && !target.deletedAt ? (
-              <Pressable
-                onPress={() => beginReply(target)}
-                style={({ pressed }) => [
-                  styles.actionMenuRow,
-                  pressed ? styles.actionMenuRowPressed : null,
-                ]}
-              >
-                <Text style={[styles.actionMenuText, isDark ? styles.actionMenuTextDark : null]}>
-                  Reply
-                </Text>
-              </Pressable>
-            ) : null}
-
-            {target &&
-            !target.deletedAt &&
-            !selectionActive &&
-            typeof onSelectMessage === 'function' ? (
-              <Pressable
-                onPress={() => {
-                  onSelectMessage(target);
-                  close();
-                }}
-                style={({ pressed }) => [
-                  styles.actionMenuRow,
-                  pressed ? styles.actionMenuRowPressed : null,
-                ]}
-                accessibilityRole="button"
-                accessibilityLabel="Select message"
-              >
-                <Text style={[styles.actionMenuText, isDark ? styles.actionMenuTextDark : null]}>
-                  Select
-                </Text>
-              </Pressable>
-            ) : null}
-
-            {copyText ? (
-              <Pressable
-                onPress={() => {
-                  void copyToClipboard(copyText);
-                  close();
-                }}
-                style={({ pressed }) => [
-                  styles.actionMenuRow,
-                  pressed ? styles.actionMenuRowPressed : null,
-                ]}
-                accessibilityRole="button"
-                accessibilityLabel="Copy message"
-              >
-                <Text style={[styles.actionMenuText, isDark ? styles.actionMenuTextDark : null]}>
-                  Copy
-                </Text>
-              </Pressable>
-            ) : null}
-
-            {(() => {
-              const t = target;
-              if (!t) return null;
-              const isOutgoingByUserSub =
-                !!myUserId && !!t.userSub && String(t.userSub) === String(myUserId);
-              const isEncryptedOutgoing =
-                !!t.encrypted && !!myPublicKey && t.encrypted.senderPublicKey === myPublicKey;
-              const isPlainOutgoing =
-                !t.encrypted &&
-                !t.groupEncrypted &&
-                (isOutgoingByUserSub
-                  ? true
-                  : normalizeUser(t.userLower ?? t.user ?? 'anon') === normalizeUser(displayName));
-              const canEdit = isOutgoingByUserSub || isEncryptedOutgoing || isPlainOutgoing;
-              if (!canEdit) return null;
-              const hasMedia = (() => {
-                if (t.deletedAt) return false;
-                if (t.encrypted) {
-                  if (!t.decryptedText) return false;
-                  const dmEnv = parseDmMediaEnvelope(String(t.decryptedText));
-                  return !!(dmEnv && normalizeDmMediaItems(dmEnv).length);
-                }
-                if (t.groupEncrypted) {
-                  if (!t.decryptedText) return false;
-                  const gEnv = parseGroupMediaEnvelope(String(t.decryptedText));
-                  return !!(gEnv && normalizeGroupMediaItems(gEnv).length);
-                }
-                if (isDm) return false;
-                const env = parseChatEnvelope(String(t.rawText ?? t.text ?? ''));
-                return !!(env && normalizeChatMediaList(env.media).length);
-              })();
-              return (
-                <>
-                  {!hasMedia ? (
-                    <Pressable
-                      onPress={() => {
-                        setInlineEditAttachmentMode('replace');
-                        beginInlineEdit(t);
-                        handlePickMedia();
-                      }}
-                      style={({ pressed }) => [
-                        styles.actionMenuRow,
-                        pressed ? styles.actionMenuRowPressed : null,
-                      ]}
-                    >
-                      <Text
-                        style={[styles.actionMenuText, isDark ? styles.actionMenuTextDark : null]}
-                      >
-                        Add attachment
-                      </Text>
-                    </Pressable>
-                  ) : null}
-
-                  {hasMedia ? (
-                    <Pressable
-                      onPress={() => {
-                        setInlineEditAttachmentMode('replace');
-                        beginInlineEdit(t);
-                        handlePickMedia();
-                      }}
-                      style={({ pressed }) => [
-                        styles.actionMenuRow,
-                        pressed ? styles.actionMenuRowPressed : null,
-                      ]}
-                    >
-                      <Text
-                        style={[styles.actionMenuText, isDark ? styles.actionMenuTextDark : null]}
-                      >
-                        Replace attachment
-                      </Text>
-                    </Pressable>
-                  ) : null}
-
-                  {hasMedia ? (
-                    <Pressable
-                      onPress={() => {
-                        setInlineEditAttachmentMode('remove');
-                        clearPendingMedia();
-                        beginInlineEdit(t);
-                      }}
-                      style={({ pressed }) => [
-                        styles.actionMenuRow,
-                        pressed ? styles.actionMenuRowPressed : null,
-                      ]}
-                    >
-                      <Text
-                        style={[styles.actionMenuText, isDark ? styles.actionMenuTextDark : null]}
-                      >
-                        Remove attachment
-                      </Text>
-                    </Pressable>
-                  ) : null}
-
+      <ScrollView
+        style={styles.actionMenuOptionsScroll}
+        contentContainerStyle={styles.actionMenuOptionsContent}
+        showsVerticalScrollIndicator
+        keyboardShouldPersistTaps="handled"
+      >
+        {/* Reactions */}
+        {target && !target.deletedAt && (!target.encrypted || !!target.decryptedText) ? (
+          <View style={styles.reactionQuickRow}>
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.reactionQuickScrollContent}
+            >
+              {quickReactions.map((emoji) => {
+                const mine = myUserId
+                  ? (target.reactions?.[emoji]?.userSubs || []).includes(myUserId)
+                  : false;
+                return (
                   <Pressable
+                    key={`quick:${emoji}`}
                     onPress={() => {
-                      setInlineEditAttachmentMode('keep');
-                      beginInlineEdit(t);
+                      sendReaction(target, emoji);
+                      close();
                     }}
                     style={({ pressed }) => [
-                      styles.actionMenuRow,
-                      pressed ? styles.actionMenuRowPressed : null,
+                      styles.reactionQuickBtn,
+                      isDark ? styles.reactionQuickBtnDark : null,
+                      mine
+                        ? isDark
+                          ? styles.reactionQuickBtnMineDark
+                          : styles.reactionQuickBtnMine
+                        : null,
+                      pressed ? { opacity: 0.85 } : null,
                     ]}
+                    accessibilityRole="button"
+                    accessibilityLabel={`React ${emoji}`}
                   >
-                    <Text
-                      style={[styles.actionMenuText, isDark ? styles.actionMenuTextDark : null]}
-                    >
-                      Edit
-                    </Text>
+                    <Text style={styles.reactionQuickEmoji}>{emoji}</Text>
                   </Pressable>
-                </>
-              );
-            })()}
-
-            {(() => {
-              const t = target;
-              if (!t || t.deletedAt) return null;
-              // Determine whether "delete for everyone" would be allowed.
-              const isOutgoingByUserSub =
-                !!myUserId && !!t.userSub && String(t.userSub) === String(myUserId);
-              const isEncryptedOutgoing =
-                !!t.encrypted && !!myPublicKey && t.encrypted.senderPublicKey === myPublicKey;
-              const isPlainOutgoing =
-                !t.encrypted &&
-                (isOutgoingByUserSub
-                  ? true
-                  : normalizeUser(t.userLower ?? t.user ?? 'anon') === normalizeUser(displayName));
-              const canDeleteForEveryone =
-                isOutgoingByUserSub || isEncryptedOutgoing || isPlainOutgoing;
-
-              return (
-                <Pressable
-                  onPress={() => {
-                    void (async () => {
-                      const choice = await uiChoice3('Delete Message?', '', {
-                        primaryText: 'Delete for Me',
-                        secondaryText: 'Delete for Everyone',
-                        tertiaryText: 'Cancel',
-                        primaryVariant: 'danger',
-                        secondaryVariant: 'danger',
-                        tertiaryVariant: 'default',
-                      });
-
-                      if (choice === 'tertiary') return;
-                      close();
-
-                      if (choice === 'primary') {
-                        await Promise.resolve(deleteForMe(t));
-                        return;
-                      }
-
-                      // secondary
-                      if (!canDeleteForEveryone) {
-                        showAlert(
-                          'Cannot delete for everyone',
-                          'Only your own messages can be deleted for everyone.',
-                        );
-                        return;
-                      }
-                      await Promise.resolve(sendDeleteForEveryone());
-                    })();
-                  }}
-                  style={({ pressed }) => [
-                    styles.actionMenuRow,
-                    pressed ? styles.actionMenuRowPressed : null,
-                  ]}
-                  accessibilityRole="button"
-                  accessibilityLabel="Delete"
-                >
-                  <Text style={[styles.actionMenuText, isDark ? styles.actionMenuTextDark : null]}>
-                    Delete…
-                  </Text>
-                </Pressable>
-              );
-            })()}
-
-            {(() => {
-              const t = target;
-              const sub = t?.userSub ? String(t.userSub) : '';
-              const label = t?.user ? String(t.user) : '';
-              const isMe = !!myUserId && !!sub && String(sub) === String(myUserId);
-              const alreadyBlocked = !!sub && blockedSubsSet.has(sub);
-              if (!t || !sub || isMe || alreadyBlocked || typeof onBlockUserSub !== 'function')
-                return null;
-              return (
-                <Pressable
-                  onPress={async () => {
-                    close();
-                    try {
-                      const ok = await uiConfirm(
-                        'Block user?',
-                        `Block ${label ? `"${label}"` : 'this user'}?\n\nYou won’t see their messages, and they won’t be able to DM you.\n\nYou can unblock them later from your Blocklist.`,
-                        { confirmText: 'Block', cancelText: 'Cancel', destructive: true },
-                      );
-                      if (!ok) return;
-                      await Promise.resolve(onBlockUserSub(sub, label));
-                      showAlert('Blocked', 'User blocked. Their messages will be hidden.');
-                    } catch (e: unknown) {
-                      showAlert('Block failed', getErrorMessage(e) || 'Failed to block user');
-                    }
-                  }}
-                  style={({ pressed }) => [
-                    styles.actionMenuRow,
-                    pressed ? styles.actionMenuRowPressed : null,
-                  ]}
-                >
-                  <Text style={[styles.actionMenuText, isDark ? styles.actionMenuTextDark : null]}>
-                    Block user
-                  </Text>
-                </Pressable>
-              );
-            })()}
+                );
+              })}
+            </ScrollView>
 
             <Pressable
               onPress={() => {
-                if (!target) return;
-                openReportForMessage(target);
+                openReactionPicker(target);
                 close();
+              }}
+              style={({ pressed }) => [
+                styles.reactionQuickMore,
+                isDark ? styles.reactionQuickMoreDark : null,
+                pressed ? { opacity: 0.85 } : null,
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel="More reactions"
+            >
+              <Text
+                style={[
+                  styles.reactionQuickMoreText,
+                  isDark ? styles.reactionQuickMoreTextDark : null,
+                ]}
+              >
+                …
+              </Text>
+            </Pressable>
+          </View>
+        ) : null}
+
+        {target?.encrypted || target?.groupEncrypted ? (
+          <Pressable
+            onPress={() => {
+              setCipherText(String(target?.rawText ?? target?.text ?? ''));
+              setCipherOpen(true);
+              close();
+            }}
+            style={({ pressed }) => [
+              styles.actionMenuRow,
+              pressed ? styles.actionMenuRowPressed : null,
+            ]}
+          >
+            <Text style={[styles.actionMenuText, isDark ? styles.actionMenuTextDark : null]}>
+              View Ciphertext
+            </Text>
+          </Pressable>
+        ) : null}
+
+        {target && !target.deletedAt ? (
+          <Pressable
+            onPress={() => beginReply(target)}
+            style={({ pressed }) => [
+              styles.actionMenuRow,
+              pressed ? styles.actionMenuRowPressed : null,
+            ]}
+          >
+            <Text style={[styles.actionMenuText, isDark ? styles.actionMenuTextDark : null]}>
+              Reply
+            </Text>
+          </Pressable>
+        ) : null}
+
+        {target &&
+        !target.deletedAt &&
+        !selectionActive &&
+        typeof onSelectMessage === 'function' ? (
+          <Pressable
+            onPress={() => {
+              onSelectMessage(target);
+              close();
+            }}
+            style={({ pressed }) => [
+              styles.actionMenuRow,
+              pressed ? styles.actionMenuRowPressed : null,
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel="Select message"
+          >
+            <Text style={[styles.actionMenuText, isDark ? styles.actionMenuTextDark : null]}>
+              Select
+            </Text>
+          </Pressable>
+        ) : null}
+
+        {copyText ? (
+          <Pressable
+            onPress={() => {
+              void copyToClipboard(copyText);
+              close();
+            }}
+            style={({ pressed }) => [
+              styles.actionMenuRow,
+              pressed ? styles.actionMenuRowPressed : null,
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel="Copy message"
+          >
+            <Text style={[styles.actionMenuText, isDark ? styles.actionMenuTextDark : null]}>
+              Copy
+            </Text>
+          </Pressable>
+        ) : null}
+
+        {(() => {
+          const t = target;
+          if (!t) return null;
+          const isOutgoingByUserSub =
+            !!myUserId && !!t.userSub && String(t.userSub) === String(myUserId);
+          const isEncryptedOutgoing =
+            !!t.encrypted && !!myPublicKey && t.encrypted.senderPublicKey === myPublicKey;
+          const isPlainOutgoing =
+            !t.encrypted &&
+            !t.groupEncrypted &&
+            (isOutgoingByUserSub
+              ? true
+              : normalizeUser(t.userLower ?? t.user ?? 'anon') === normalizeUser(displayName));
+          const canEdit = isOutgoingByUserSub || isEncryptedOutgoing || isPlainOutgoing;
+          if (!canEdit) return null;
+          const hasMedia = (() => {
+            if (t.deletedAt) return false;
+            if (t.encrypted) {
+              if (!t.decryptedText) return false;
+              const dmEnv = parseDmMediaEnvelope(String(t.decryptedText));
+              return !!(dmEnv && normalizeDmMediaItems(dmEnv).length);
+            }
+            if (t.groupEncrypted) {
+              if (!t.decryptedText) return false;
+              const gEnv = parseGroupMediaEnvelope(String(t.decryptedText));
+              return !!(gEnv && normalizeGroupMediaItems(gEnv).length);
+            }
+            if (isDm) return false;
+            const env = parseChatEnvelope(String(t.rawText ?? t.text ?? ''));
+            return !!(env && normalizeChatMediaList(env.media).length);
+          })();
+          return (
+            <>
+              {!hasMedia ? (
+                <Pressable
+                  onPress={() => {
+                    setInlineEditAttachmentMode('replace');
+                    beginInlineEdit(t);
+                    handlePickMedia();
+                  }}
+                  style={({ pressed }) => [
+                    styles.actionMenuRow,
+                    pressed ? styles.actionMenuRowPressed : null,
+                  ]}
+                >
+                  <Text style={[styles.actionMenuText, isDark ? styles.actionMenuTextDark : null]}>
+                    Add attachment
+                  </Text>
+                </Pressable>
+              ) : null}
+
+              {hasMedia ? (
+                <Pressable
+                  onPress={() => {
+                    setInlineEditAttachmentMode('replace');
+                    beginInlineEdit(t);
+                    handlePickMedia();
+                  }}
+                  style={({ pressed }) => [
+                    styles.actionMenuRow,
+                    pressed ? styles.actionMenuRowPressed : null,
+                  ]}
+                >
+                  <Text style={[styles.actionMenuText, isDark ? styles.actionMenuTextDark : null]}>
+                    Replace attachment
+                  </Text>
+                </Pressable>
+              ) : null}
+
+              {hasMedia ? (
+                <Pressable
+                  onPress={() => {
+                    setInlineEditAttachmentMode('remove');
+                    clearPendingMedia();
+                    beginInlineEdit(t);
+                  }}
+                  style={({ pressed }) => [
+                    styles.actionMenuRow,
+                    pressed ? styles.actionMenuRowPressed : null,
+                  ]}
+                >
+                  <Text style={[styles.actionMenuText, isDark ? styles.actionMenuTextDark : null]}>
+                    Remove attachment
+                  </Text>
+                </Pressable>
+              ) : null}
+
+              <Pressable
+                onPress={() => {
+                  setInlineEditAttachmentMode('keep');
+                  beginInlineEdit(t);
+                }}
+                style={({ pressed }) => [
+                  styles.actionMenuRow,
+                  pressed ? styles.actionMenuRowPressed : null,
+                ]}
+              >
+                <Text style={[styles.actionMenuText, isDark ? styles.actionMenuTextDark : null]}>
+                  Edit
+                </Text>
+              </Pressable>
+            </>
+          );
+        })()}
+
+        {(() => {
+          const t = target;
+          if (!t || t.deletedAt) return null;
+          // Determine whether "delete for everyone" would be allowed.
+          const isOutgoingByUserSub =
+            !!myUserId && !!t.userSub && String(t.userSub) === String(myUserId);
+          const isEncryptedOutgoing =
+            !!t.encrypted && !!myPublicKey && t.encrypted.senderPublicKey === myPublicKey;
+          const isPlainOutgoing =
+            !t.encrypted &&
+            (isOutgoingByUserSub
+              ? true
+              : normalizeUser(t.userLower ?? t.user ?? 'anon') === normalizeUser(displayName));
+          const canDeleteForEveryone =
+            isOutgoingByUserSub || isEncryptedOutgoing || isPlainOutgoing;
+
+          return (
+            <Pressable
+              onPress={() => {
+                void (async () => {
+                  const choice = await uiChoice3('Delete Message?', '', {
+                    primaryText: 'Delete for Me',
+                    secondaryText: 'Delete for Everyone',
+                    tertiaryText: 'Cancel',
+                    primaryVariant: 'danger',
+                    secondaryVariant: 'danger',
+                    tertiaryVariant: 'default',
+                  });
+
+                  if (choice === 'tertiary') return;
+                  close();
+
+                  if (choice === 'primary') {
+                    await Promise.resolve(deleteForMe(t));
+                    return;
+                  }
+
+                  // secondary
+                  if (!canDeleteForEveryone) {
+                    showAlert(
+                      'Cannot delete for everyone',
+                      'Only your own messages can be deleted for everyone.',
+                    );
+                    return;
+                  }
+                  await Promise.resolve(sendDeleteForEveryone());
+                })();
+              }}
+              style={({ pressed }) => [
+                styles.actionMenuRow,
+                pressed ? styles.actionMenuRowPressed : null,
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel="Delete"
+            >
+              <Text style={[styles.actionMenuText, isDark ? styles.actionMenuTextDark : null]}>
+                Delete…
+              </Text>
+            </Pressable>
+          );
+        })()}
+
+        {(() => {
+          const t = target;
+          const sub = t?.userSub ? String(t.userSub) : '';
+          const label = t?.user ? String(t.user) : '';
+          const isMe = !!myUserId && !!sub && String(sub) === String(myUserId);
+          const alreadyBlocked = !!sub && blockedSubsSet.has(sub);
+          if (!t || !sub || isMe || alreadyBlocked || typeof onBlockUserSub !== 'function')
+            return null;
+          return (
+            <Pressable
+              onPress={async () => {
+                close();
+                try {
+                  const ok = await uiConfirm(
+                    'Block user?',
+                    `Block ${label ? `"${label}"` : 'this user'}?\n\nYou won’t see their messages, and they won’t be able to DM you.\n\nYou can unblock them later from your Blocklist.`,
+                    { confirmText: 'Block', cancelText: 'Cancel', destructive: true },
+                  );
+                  if (!ok) return;
+                  await Promise.resolve(onBlockUserSub(sub, label));
+                  showAlert('Blocked', 'User blocked. Their messages will be hidden.');
+                } catch (e: unknown) {
+                  showAlert('Block failed', getErrorMessage(e) || 'Failed to block user');
+                }
               }}
               style={({ pressed }) => [
                 styles.actionMenuRow,
@@ -976,11 +940,48 @@ export function MessageActionMenuModal({
               ]}
             >
               <Text style={[styles.actionMenuText, isDark ? styles.actionMenuTextDark : null]}>
-                Report…
+                Block user
               </Text>
             </Pressable>
-          </ScrollView>
-        </Animated.View>
+          );
+        })()}
+
+        <Pressable
+          onPress={() => {
+            if (!target) return;
+            openReportForMessage(target);
+            close();
+          }}
+          style={({ pressed }) => [
+            styles.actionMenuRow,
+            pressed ? styles.actionMenuRowPressed : null,
+          ]}
+        >
+          <Text style={[styles.actionMenuText, isDark ? styles.actionMenuTextDark : null]}>
+            Report…
+          </Text>
+        </Pressable>
+      </ScrollView>
+    </Animated.View>
+  );
+
+  if (Platform.OS === 'ios') {
+    if (!visible) return <></>;
+    return (
+      <View style={[StyleSheet.absoluteFill, { zIndex: 10000 }]}>
+        <View style={styles.actionMenuOverlay}>
+          <Pressable style={StyleSheet.absoluteFill} onPress={close} />
+          {card}
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <Modal visible={visible} transparent animationType="fade">
+      <View style={styles.actionMenuOverlay}>
+        <Pressable style={StyleSheet.absoluteFill} onPress={close} />
+        {card}
       </View>
     </Modal>
   );

--- a/frontend/src/features/chat/components/MessageActionMenuModal.tsx
+++ b/frontend/src/features/chat/components/MessageActionMenuModal.tsx
@@ -23,7 +23,6 @@ import {
   fileIconNameForMedia,
 } from '../../../utils/mediaKinds';
 import { getCopyableMessageText } from '../getCopyableMessageText';
-import type { ChatCopyToClipboardOptions } from '../useChatCopyToClipboard';
 import {
   normalizeChatMediaList,
   normalizeDmMediaItems,
@@ -34,6 +33,7 @@ import {
   parseGroupMediaEnvelope,
 } from '../parsers';
 import type { ChatMessage } from '../types';
+import type { ChatCopyToClipboardOptions } from '../useChatCopyToClipboard';
 
 function getErrorMessage(err: unknown): string {
   if (err instanceof Error) return err.message || 'Unknown error';

--- a/frontend/src/features/chat/components/MessageActionMenuModal.tsx
+++ b/frontend/src/features/chat/components/MessageActionMenuModal.tsx
@@ -23,6 +23,7 @@ import {
   fileIconNameForMedia,
 } from '../../../utils/mediaKinds';
 import { getCopyableMessageText } from '../getCopyableMessageText';
+import type { ChatCopyToClipboardOptions } from '../useChatCopyToClipboard';
 import {
   normalizeChatMediaList,
   normalizeDmMediaItems,
@@ -103,7 +104,7 @@ type Props = {
   showAlert: (title: string, body: string) => void;
 
   close: () => void;
-  copyToClipboard: (text: string) => Promise<void>;
+  copyToClipboard: (text: string, opts?: ChatCopyToClipboardOptions) => Promise<boolean>;
   selectionActive: boolean;
   onSelectMessage?: (msg: ChatMessage) => void;
   sendReaction: (msg: ChatMessage, emoji: string) => void;

--- a/frontend/src/features/chat/useChannelSettingsPanelActions.ts
+++ b/frontend/src/features/chat/useChannelSettingsPanelActions.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Platform } from 'react-native';
 
 import type { ChannelMeta } from './useChannelRoster';
 
@@ -51,14 +52,20 @@ export function useChannelSettingsPanelActions(opts: {
         try {
           setChannelMeta((p) => (p ? { ...p, isPublic: next } : p));
           await channelUpdate('setPublic', { isPublic: next });
-          showToast(next ? 'Channel is now public' : 'Channel is now private', 'success');
-          // Theme-appropriate FYI modal (not a gate).
+
+          // Always show the informational modal (all platforms).
           void uiAlert(
             next ? 'Channel is public' : 'Channel is Private',
             next
-              ? 'This channel is now discoverable in search, and people can join publicly'
-              : 'This channel is no longer discoverable in search to non-members, and people cannot join it publicly',
+              ? 'This channel is now discoverable in search, and people can join publicly.'
+              : 'This channel is no longer discoverable in search to non-members, and people cannot join it publicly.',
           );
+
+          // Only show the toast on non‑iOS platforms; on iOS it appears to
+          // contribute to touch issues when combined with other overlays.
+          if (Platform.OS !== 'ios') {
+            showToast(next ? 'Channel is now public' : 'Channel is now private', 'success');
+          }
         } finally {
           setChannelActionBusy(false);
         }

--- a/frontend/src/features/chat/useChatAdminOps.ts
+++ b/frontend/src/features/chat/useChatAdminOps.ts
@@ -246,7 +246,7 @@ export function useChatAdminOps(opts: {
     }
 
     if (!skipStandardConfirm) {
-      const ok = await uiConfirm('Leave channel?', 'You will stop receiving new messages', {
+      const ok = await uiConfirm('Leave Channel?', 'You will stop receiving new messages', {
         confirmText: 'Leave',
         cancelText: 'Cancel',
         destructive: true,

--- a/frontend/src/features/chat/useChatCopyToClipboard.ts
+++ b/frontend/src/features/chat/useChatCopyToClipboard.ts
@@ -2,14 +2,26 @@ import * as React from 'react';
 
 import { copyToClipboardSafe } from '../../utils/clipboard';
 
-export function useChatCopyToClipboard(opts: { openInfo: (title: string, body: string) => void }): {
-  copyToClipboard: (text: string) => Promise<void>;
+export type ChatCopyToClipboardOptions = {
+  /**
+   * When true, do not run `onCopied` (skip global toast).
+   * Use for AI Helper — it shows inline “Copied” on the button for iOS/Android/web.
+   */
+  skipToast?: boolean;
+};
+
+export function useChatCopyToClipboard(opts: {
+  openInfo: (title: string, body: string) => void;
+  /** Called after a successful copy (e.g. in-app toast — iOS has no system “Copied” banner like some Androids). */
+  onCopied?: () => void;
+}): {
+  copyToClipboard: (text: string, opts?: ChatCopyToClipboardOptions) => Promise<boolean>;
 } {
-  const { openInfo } = opts;
+  const { openInfo, onCopied } = opts;
 
   const copyToClipboard = React.useCallback(
-    async (text: string) => {
-      await copyToClipboardSafe({
+    async (text: string, copyOpts?: ChatCopyToClipboardOptions) => {
+      return copyToClipboardSafe({
         text,
         onUnavailable: () => {
           openInfo(
@@ -17,9 +29,10 @@ export function useChatCopyToClipboard(opts: { openInfo: (title: string, body: s
             'Your current build does not include clipboard support yet. Rebuild the dev client to enable Copy.',
           );
         },
+        onCopied: copyOpts?.skipToast ? undefined : onCopied,
       });
     },
-    [openInfo],
+    [openInfo, onCopied],
   );
 
   return { copyToClipboard };

--- a/frontend/src/features/chat/useMessageActionMenu.ts
+++ b/frontend/src/features/chat/useMessageActionMenu.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Animated, Platform } from 'react-native';
+import { Animated, Keyboard, Platform } from 'react-native';
 
 export function useMessageActionMenu<TTarget = unknown>() {
   const [open, setOpen] = React.useState(false);
@@ -14,6 +14,9 @@ export function useMessageActionMenu<TTarget = unknown>() {
   const openMenu = React.useCallback(
     (msg: TTarget, nextAnchor?: { x: number; y: number }) => {
       if (!msg) return;
+      // iOS often keeps the IME up on long-press, which clips the anchored menu; Android/web
+      // behave fine without forcing dismiss.
+      if (Platform.OS === 'ios') Keyboard.dismiss();
       setTarget(msg);
       if (nextAnchor && Number.isFinite(nextAnchor.x) && Number.isFinite(nextAnchor.y))
         setAnchor(nextAnchor);

--- a/frontend/src/features/chat/useMessageActionMenu.ts
+++ b/frontend/src/features/chat/useMessageActionMenu.ts
@@ -14,9 +14,8 @@ export function useMessageActionMenu<TTarget = unknown>() {
   const openMenu = React.useCallback(
     (msg: TTarget, nextAnchor?: { x: number; y: number }) => {
       if (!msg) return;
-      // iOS often keeps the IME up on long-press, which clips the anchored menu; Android/web
-      // behave fine without forcing dismiss.
-      if (Platform.OS === 'ios') Keyboard.dismiss();
+      // Dismiss IME so the anchored menu isn’t clipped; redundant on some platforms but safe.
+      Keyboard.dismiss();
       setTarget(msg);
       if (nextAnchor && Number.isFinite(nextAnchor.x) && Number.isFinite(nextAnchor.y))
         setAnchor(nextAnchor);

--- a/frontend/src/features/guest/components/GuestGlobalScreenOverlays.tsx
+++ b/frontend/src/features/guest/components/GuestGlobalScreenOverlays.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal, Platform, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { GlobalAboutContent } from '../../../components/globalAbout/GlobalAboutContent';
 import { HeaderMenuModal } from '../../../components/HeaderMenuModal';

--- a/frontend/src/features/guest/components/GuestGlobalScreenOverlays.tsx
+++ b/frontend/src/features/guest/components/GuestGlobalScreenOverlays.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Modal, Platform, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { GlobalAboutContent } from '../../../components/globalAbout/GlobalAboutContent';
 import { HeaderMenuModal } from '../../../components/HeaderMenuModal';
@@ -134,6 +134,10 @@ export function GuestGlobalScreenOverlays({
   confirmLinkModal: React.ReactNode;
   styles: typeof import('../../../screens/GuestGlobalScreen.styles').styles;
 }): React.JSX.Element {
+  const scheduleOpen = React.useCallback((fn: () => void) => {
+    fn();
+  }, []);
+
   return (
     <>
       <HeaderMenuModal
@@ -150,12 +154,12 @@ export function GuestGlobalScreenOverlays({
             label: 'About',
             onPress: () => {
               setMenuOpen(false);
-              if (isChannel) {
-                setChannelAboutText(String(activeChannelMetaAboutText || ''));
-                setChannelAboutOpen(true);
-                return;
-              }
-              setGlobalAboutOpen(true);
+              scheduleOpen(() => {
+                if (isChannel) {
+                  setChannelAboutText(String(activeChannelMetaAboutText || ''));
+                  setChannelAboutOpen(true);
+                } else setGlobalAboutOpen(true);
+              });
             },
           },
           {
@@ -163,7 +167,7 @@ export function GuestGlobalScreenOverlays({
             label: 'Sign in',
             onPress: () => {
               setMenuOpen(false);
-              requestSignIn();
+              scheduleOpen(() => requestSignIn());
             },
           },
         ]}

--- a/frontend/src/screens/ChatScreen.tsx
+++ b/frontend/src/screens/ChatScreen.tsx
@@ -7,7 +7,7 @@ import { getRandomBytes } from 'expo-crypto';
 import * as ImagePicker from 'expo-image-picker';
 import React from 'react';
 import type { AppStateStatus, TextInput } from 'react-native';
-import { AppState, Platform, useWindowDimensions } from 'react-native';
+import { AppState, Keyboard, Platform, useWindowDimensions } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { AI_API_URL, API_URL, CDN_URL, WS_URL } from '../config/env';
@@ -227,21 +227,48 @@ export default function ChatScreen({
   // Android can report different bottom insets when an input is focused / keyboard shows.
   // Cache a stable bottom inset so the composer doesn't "jump" or change height.
   const [androidBottomInsetStable, setAndroidBottomInsetStable] = React.useState<number>(0);
+  // Track whether the iOS keyboard is visible so we can adjust padding separately
+  // for "idle" vs "keyboard-up" states.
+  const [iosKeyboardVisible, setIosKeyboardVisible] = React.useState(false);
   React.useEffect(() => {
     if (Platform.OS !== 'android') return;
     const b =
       typeof insets.bottom === 'number' && Number.isFinite(insets.bottom) ? insets.bottom : 0;
     // Keep the maximum seen value (gesture/nav area). When the keyboard shows, some devices report 0.
     if (b > androidBottomInsetStable) setAndroidBottomInsetStable(b);
-  }, [androidBottomInsetStable, insets.bottom]);
+  }, [androidBottomInsetStable, insets.bottom, iosKeyboardVisible]);
+
+  React.useEffect(() => {
+    if (Platform.OS !== 'ios') return;
+    const showSub = Keyboard.addListener('keyboardDidShow', () => setIosKeyboardVisible(true));
+    const hideSub = Keyboard.addListener('keyboardDidHide', () => setIosKeyboardVisible(false));
+    return () => {
+      showSub.remove();
+      hideSub.remove();
+    };
+  }, []);
 
   const composerSafeAreaStyle = React.useMemo(() => {
-    const bottomInset =
-      Platform.OS === 'android'
-        ? Math.min(androidBottomInsetStable, ANDROID_COMPOSER_BOTTOM_PAD_MAX)
-        : insets.bottom;
-    return { paddingBottom: bottomInset };
-  }, [androidBottomInsetStable, insets.bottom]);
+    if (Platform.OS === 'android') {
+      const bottomInset = Math.min(androidBottomInsetStable, ANDROID_COMPOSER_BOTTOM_PAD_MAX);
+      return { paddingBottom: bottomInset };
+    }
+    if (Platform.OS === 'ios') {
+      const raw =
+        typeof insets.bottom === 'number' && Number.isFinite(insets.bottom) ? insets.bottom : 0;
+      if (iosKeyboardVisible) {
+        // When keyboard is up, respect the full inset and add a small buffer so
+        // the keyboard doesn't visually touch the bottom of the input.
+        return { paddingBottom: raw };
+      }
+      // When keyboard is hidden, reduce the inset so the idle gap is smaller (tighter than before).
+      const IOS_REDUCE_PX = 20;
+      const bottomInset = Math.max(0, raw - IOS_REDUCE_PX);
+      return { paddingBottom: bottomInset };
+    }
+    // Web and any other platforms: preserve original behavior.
+    return { paddingBottom: insets.bottom };
+  }, [androidBottomInsetStable, insets.bottom, iosKeyboardVisible]);
   const composerBottomInsetBgHeight = Platform.OS === 'android' ? androidBottomInsetStable : 0;
   const composerHorizontalInsetsStyle = React.useMemo(
     () => ({ paddingLeft: 12 + insets.left, paddingRight: 12 + insets.right }),

--- a/frontend/src/screens/ChatScreen.tsx
+++ b/frontend/src/screens/ChatScreen.tsx
@@ -495,6 +495,19 @@ export default function ChatScreen({
     maxAttachmentsPerMessage: MAX_ATTACHMENTS_PER_MESSAGE,
     showAlert,
   });
+
+  // Leaving a chat (DM / channel / group) should end inline edit, reply, and attachment-replace
+  // flows so another conversation doesn't show stale UI ("Finish editing…", open editor, etc.).
+  React.useEffect(() => {
+    setInlineEditTargetId(null);
+    setInlineEditDraft('');
+    setInlineEditAttachmentMode('keep');
+    setInlineEditUploading(false);
+    clearPendingMedia();
+    setReplyTarget(null);
+    closeMessageActions();
+  }, [conversationId, clearPendingMedia, closeMessageActions]);
+
   const cdnMedia = useCdnUrlCache(CDN_URL);
   const mediaUrlByPath = cdnMedia.urlByPath;
   const cdnAvatar = useCdnUrlCache(CDN_URL);

--- a/frontend/src/screens/ChatScreen.tsx
+++ b/frontend/src/screens/ChatScreen.tsx
@@ -584,17 +584,38 @@ export default function ChatScreen({
   ]);
 
   const { toast, anim: toastAnim, showToast } = useToast();
+  const viewerOpenRef = React.useRef(false);
+  const pendingViewerSaveToastRef = React.useRef<null | {
+    kind: 'success' | 'error';
+    message: string;
+  }>(null);
 
   const onViewerSavePermissionDenied = React.useCallback(() => {
+    if (Platform.OS === 'ios' && viewerOpenRef.current) {
+      pendingViewerSaveToastRef.current = {
+        kind: 'error',
+        message: 'Allow Photos permission to save.',
+      };
+      return;
+    }
     showToast('Allow Photos permission to save.', 'error');
   }, [showToast]);
   const onViewerSaveSuccess = React.useCallback(() => {
+    if (Platform.OS === 'ios' && viewerOpenRef.current) {
+      pendingViewerSaveToastRef.current = { kind: 'success', message: 'Media saved' };
+      return;
+    }
     showToast('Media saved', 'success');
   }, [showToast]);
   const onViewerSaveError = React.useCallback(
     (msg: string) => {
       const m = String(msg || '');
-      showToast(m.length > 120 ? `${m.slice(0, 120)}…` : m, 'error');
+      const clipped = m.length > 120 ? `${m.slice(0, 120)}…` : m;
+      if (Platform.OS === 'ios' && viewerOpenRef.current) {
+        pendingViewerSaveToastRef.current = { kind: 'error', message: clipped };
+        return;
+      }
+      showToast(clipped, 'error');
     },
     [showToast],
   );
@@ -633,13 +654,19 @@ export default function ChatScreen({
   const saveViewerToDevice = React.useCallback(async () => {
     if (viewerSaving) return;
     const vs = viewerBase.state;
-    if (!vs) return;
+    if (!vs) {
+      onViewerSaveError('No media selected to save.');
+      return;
+    }
 
     setViewerSaving(true);
     try {
       if (vs.mode === 'global') {
         const it = vs.globalItems?.[vs.index];
-        if (!it?.url) return;
+        if (!it?.url) {
+          onViewerSaveError('Could not resolve media URL for save.');
+          return;
+        }
         await saveMediaUrlToDevice({
           url: it.url,
           kind: it.kind,
@@ -655,14 +682,20 @@ export default function ChatScreen({
         const msg = vs.dmMsg;
         const it = vs.dmItems?.[vs.index];
         const key = it?.media?.path;
-        if (!msg || !it || !key) return;
+        if (!msg || !it || !key) {
+          onViewerSaveError('Could not resolve encrypted media for save.');
+          return;
+        }
         const uri =
           dmFileUriByPath[key] ||
           (await decryptDmFileToCacheUri(
             msg,
             it as unknown as Parameters<typeof decryptDmFileToCacheUri>[1],
           ).catch(() => ''));
-        if (!uri) return;
+        if (!uri) {
+          onViewerSaveError('Could not decrypt media for save.');
+          return;
+        }
         const kind =
           it.media.kind === 'video' ? 'video' : it.media.kind === 'image' ? 'image' : 'file';
         await saveMediaUrlToDevice({
@@ -680,14 +713,20 @@ export default function ChatScreen({
         const msg = vs.gdmMsg;
         const it = vs.gdmItems?.[vs.index];
         const key = it?.media?.path;
-        if (!msg || !it || !key) return;
+        if (!msg || !it || !key) {
+          onViewerSaveError('Could not resolve group media for save.');
+          return;
+        }
         const uri =
           dmFileUriByPath[key] ||
           (await decryptGroupFileToCacheUri(
             msg,
             it as unknown as Parameters<typeof decryptGroupFileToCacheUri>[1],
           ).catch(() => ''));
-        if (!uri) return;
+        if (!uri) {
+          onViewerSaveError('Could not decrypt group media for save.');
+          return;
+        }
         const kind =
           it.media.kind === 'video' ? 'video' : it.media.kind === 'image' ? 'image' : 'file';
         await saveMediaUrlToDevice({
@@ -699,6 +738,9 @@ export default function ChatScreen({
           onError: onViewerSaveError,
         });
       }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err || 'Unknown save failure');
+      onViewerSaveError(msg);
     } finally {
       setViewerSaving(false);
     }
@@ -721,6 +763,15 @@ export default function ChatScreen({
     }),
     [saveViewerToDevice, viewerBase, viewerSaving],
   );
+  React.useEffect(() => {
+    viewerOpenRef.current = !!viewer.open;
+    if (Platform.OS !== 'ios') return;
+    if (viewer.open) return;
+    const pending = pendingViewerSaveToastRef.current;
+    if (!pending) return;
+    pendingViewerSaveToastRef.current = null;
+    showToast(pending.message, pending.kind);
+  }, [showToast, viewer.open]);
   // DM media caches + decrypt helpers are managed by useChatMediaDecryptCache().
   const inFlightDmViewerDecryptRef = React.useRef<Set<string>>(new Set());
   const [attachOpen, setAttachOpen] = React.useState<boolean>(false);

--- a/frontend/src/screens/ChatScreen.tsx
+++ b/frontend/src/screens/ChatScreen.tsx
@@ -1706,7 +1706,10 @@ export default function ChatScreen({
   useChatConversationJoin({ activeConversationId, wsRef, pendingJoinConversationIdRef });
 
   const { onChangeInput } = useChatComposerInput({ setInput, inputRef, isTypingRef, sendTyping });
-  const { copyToClipboard } = useChatCopyToClipboard({ openInfo });
+  const { copyToClipboard } = useChatCopyToClipboard({
+    openInfo,
+    onCopied: () => showToast('Copied', 'success'),
+  });
 
   const onPressMessage = useChatPressToDecrypt({
     isDm,

--- a/frontend/src/utils/clipboard.ts
+++ b/frontend/src/utils/clipboard.ts
@@ -1,12 +1,16 @@
 export async function copyToClipboardSafe(opts: {
   text: string;
   onUnavailable: () => void;
-}): Promise<void> {
-  const { text, onUnavailable } = opts;
+  onCopied?: () => void;
+}): Promise<boolean> {
+  const { text, onUnavailable, onCopied } = opts;
   try {
     const Clipboard = await import('expo-clipboard');
     await Clipboard.setStringAsync(text);
+    onCopied?.();
+    return true;
   } catch {
     onUnavailable();
+    return false;
   }
 }

--- a/frontend/src/utils/deferForModalTransition.ts
+++ b/frontend/src/utils/deferForModalTransition.ts
@@ -1,0 +1,12 @@
+import { InteractionManager, Platform } from 'react-native';
+
+/**
+ * Wait until after the current transition/animation (e.g. native Modal dismiss).
+ * Use before showing a second modal/prompt on iOS to avoid nested-modal freezes.
+ */
+export async function deferForModalTransition(): Promise<void> {
+  if (Platform.OS === 'web') return;
+  await new Promise<void>((resolve) => {
+    InteractionManager.runAfterInteractions(() => resolve());
+  });
+}

--- a/frontend/src/utils/saveMediaToDevice.ts
+++ b/frontend/src/utils/saveMediaToDevice.ts
@@ -22,7 +22,9 @@ function getErrorMessage(err: unknown): string {
 }
 
 type ExpoFileSystemLike = {
-  Paths?: { cache?: string; document?: string };
+  Paths?: { cache?: unknown; document?: unknown };
+  cacheDirectory?: string;
+  documentDirectory?: string;
   getInfoAsync?: (uri: string) => Promise<{ exists?: boolean }>;
   deleteAsync?: (uri: string, opts?: { idempotent?: boolean }) => Promise<void>;
   makeDirectoryAsync?: (uri: string, opts?: { intermediates?: boolean }) => Promise<void>;
@@ -59,9 +61,9 @@ function isUserCancelledError(msg: string): boolean {
 
 async function ensureEmptyDest(fs: ExpoFileSystemLike, uri: string): Promise<void> {
   try {
-    if (typeof fs.getInfoAsync !== 'function' || typeof fs.deleteAsync !== 'function') return;
-    const info = await fs.getInfoAsync(uri);
-    if (info?.exists) await fs.deleteAsync(uri, { idempotent: true });
+    if (typeof fs.deleteAsync !== 'function') return;
+    // Avoid deprecated getInfoAsync; idempotent delete is sufficient for our temp paths.
+    await fs.deleteAsync(uri, { idempotent: true });
   } catch {
     // ignore
   }
@@ -88,6 +90,42 @@ function parseDataUriBase64(url: string): string | null {
   const b64 = url.slice(comma + 1);
   const isBase64 = /;base64/i.test(header);
   return isBase64 ? b64 : null;
+}
+
+function toFileUri(uri: string): string {
+  const u = String(uri || '').trim();
+  if (!u) return u;
+  if (u.startsWith('file://')) return u;
+  if (u.startsWith('/')) return `file://${u}`;
+  return u;
+}
+
+function dirLikeToString(v: unknown): string {
+  if (typeof v === 'string') return v.trim();
+  if (isRecord(v)) {
+    const uri = v.uri;
+    if (typeof uri === 'string') return uri.trim();
+    const path = (v as Record<string, unknown>).path;
+    if (typeof path === 'string') return path.trim();
+  }
+  return '';
+}
+
+function pickWritableRoot(...candidates: unknown[]): string {
+  for (const c of candidates) {
+    const s = dirLikeToString(c);
+    if (s) return s;
+  }
+  return '';
+}
+
+function tryRequireLegacyFileSystem(): ExpoFileSystemLike {
+  try {
+    const legacyMod: unknown = require('expo-file-system/legacy');
+    return isRecord(legacyMod) ? (legacyMod as ExpoFileSystemLike) : {};
+  } catch {
+    return {};
+  }
 }
 
 const ANDROID_SAF_DIR_KEY = 'downloads:safDirectoryUri:v1';
@@ -121,7 +159,7 @@ export async function saveMediaUrlToDevice({
   url,
   kind,
   fileName,
-  onPermissionDenied,
+  onPermissionDenied: _onPermissionDenied,
   onSuccess,
   onError,
 }: {
@@ -144,7 +182,6 @@ export async function saveMediaUrlToDevice({
   const downloadName = `${baseName}.${ext}`;
   const tmpId = `${Date.now()}-${Math.floor(Math.random() * 1_000_000_000)}`;
   const uniqueLeaf = `${tmpId}-${downloadName}`;
-  const uniqueDir = `dl-${tmpId}`;
 
   try {
     // Web: use a browser download flow (MediaLibrary/FileSystem aren't applicable).
@@ -213,10 +250,14 @@ export async function saveMediaUrlToDevice({
       }
     }
 
-    // Native "download/save" flow: for files + audio + images + videos.
-    // - iOS: share sheet so user can "Save to Files" (handles name collisions like (1))
-    // - Android: Downloads module (above), with fallbacks below if module not present
-    if (kind === 'file' || kind === 'image' || kind === 'video') {
+    // Native "download/save" flow:
+    // - Android: files/images/videos go through Downloads/share fallbacks.
+    // - iOS: use the system share/save sheet for all kinds to maximize reliability in dev-client builds.
+    if (
+      kind === 'file' ||
+      Platform.OS === 'ios' ||
+      (Platform.OS === 'android' && (kind === 'image' || kind === 'video'))
+    ) {
       const fsMod: unknown = require('expo-file-system');
       const fs: ExpoFileSystemLike = isRecord(fsMod) ? (fsMod as ExpoFileSystemLike) : {};
       const mimeType = mimeTypeFromExt(extFromName || ext);
@@ -224,8 +265,7 @@ export async function saveMediaUrlToDevice({
       // Android: fallback path when the native module isn't present (e.g. old dev-client build).
       if (Platform.OS === 'android') {
         // SAF lives on expo-file-system legacy in many builds.
-        const legacyMod: unknown = require('expo-file-system/legacy');
-        const legacy: any = isRecord(legacyMod) ? legacyMod : {};
+        const legacy: any = tryRequireLegacyFileSystem();
         const SAF = legacy.StorageAccessFramework;
         const encBase64 = legacy.EncodingType?.Base64;
         const readAsStringAsync = legacy.readAsStringAsync as
@@ -371,126 +411,70 @@ export async function saveMediaUrlToDevice({
         return;
       }
 
-      // iOS: use the system share sheet ("Save to Files" is available there).
-      // If it's already a local file, prompt directly.
+      // iOS: use system share sheet. Build a local file first for remote/data URLs.
       if (url.startsWith('file:')) {
-        await shareLocalFile({ localUri: url, mimeType });
+        await shareLocalFile({ localUri: toFileUri(url), mimeType });
         if (onSuccess) onSuccess();
         return;
       }
 
-      // Download to a *unique folder* but keep the leaf filename intact so the share sheet
-      // shows the real filename (not a temp prefix).
-      const root = fs.Paths?.cache ?? fs.Paths?.document;
+      const legacy: ExpoFileSystemLike = tryRequireLegacyFileSystem();
+      const root = pickWritableRoot(
+        fs.Paths?.cache,
+        fs.Paths?.document,
+        fs.cacheDirectory,
+        fs.documentDirectory,
+        legacy.cacheDirectory,
+        legacy.documentDirectory,
+      );
       if (!root) throw new Error('No writable cache directory');
-      const File = fs.File;
-      if (!File) throw new Error('File API not available');
-      const dir = `${root.replace(/\/+$/, '')}/dl-${tmpId}`;
-      if (typeof fs.makeDirectoryAsync === 'function') {
-        await fs.makeDirectoryAsync(dir, { intermediates: true }).catch(() => {});
-      }
-      const dest = new File(dir, downloadName);
-      await ensureEmptyDest(fs, dest.uri);
+      const rootBase = root.replace(/\/+$/, '');
+      // iOS/dev-client: write directly to known cache root to avoid mkdir path issues.
+      const localDestUri = `${rootBase}/${tmpId}-${downloadName}`;
+      await ensureEmptyDest(fs, localDestUri);
+      await ensureEmptyDest(legacy, localDestUri);
 
-      // Handle data URIs by writing bytes to cache.
+      let localUri = '';
       if (url.startsWith('data:')) {
         const b64 = parseDataUriBase64(url);
         if (!b64) throw new Error('Unsupported data URI encoding');
-        if (typeof dest.write !== 'function') throw new Error('File write API not available');
-        await ensureEmptyDest(fs, dest.uri);
-        await dest.write(b64, { encoding: 'base64' });
-        await shareLocalFile({ localUri: dest.uri, mimeType });
-        if (onSuccess) onSuccess();
-        return;
-      }
-
-      // Remote URL: download to cache then prompt.
-      if (typeof dest?.downloadFileAsync === 'function') {
-        await dest.downloadFileAsync(url);
-      } else if (typeof File?.downloadFileAsync === 'function') {
-        await File.downloadFileAsync(url, dest);
+        if (typeof fs.writeAsStringAsync === 'function' && fs.EncodingType?.Base64) {
+          await fs.writeAsStringAsync(localDestUri, b64, { encoding: fs.EncodingType.Base64 });
+          localUri = toFileUri(localDestUri);
+        } else if (typeof legacy.writeAsStringAsync === 'function' && legacy.EncodingType?.Base64) {
+          await legacy.writeAsStringAsync(localDestUri, b64, {
+            encoding: legacy.EncodingType.Base64,
+          });
+          localUri = toFileUri(localDestUri);
+        } else {
+          throw new Error('File write API not available');
+        }
       } else {
-        throw new Error('File download API not available');
+        const File = fs.File;
+        // iOS/dev-client: use legacy downloadAsync to avoid deprecation-guard exceptions.
+        if (typeof legacy.downloadAsync === 'function') {
+          const out = await legacy.downloadAsync(url, localDestUri);
+          localUri = toFileUri(String(out?.uri || localDestUri));
+        }
+        if (!localUri && File) {
+          const dest = new File(rootBase, `${tmpId}-${downloadName}`);
+          await ensureEmptyDest(fs, dest.uri);
+          if (typeof dest.downloadFileAsync === 'function') {
+            await dest.downloadFileAsync(url);
+            localUri = toFileUri(dest.uri);
+          } else if (typeof File.downloadFileAsync === 'function') {
+            await File.downloadFileAsync(url, dest);
+            localUri = toFileUri(dest.uri);
+          }
+        }
+        if (!localUri) throw new Error('File download API not available');
       }
 
-      await shareLocalFile({ localUri: dest.uri, mimeType });
+      await shareLocalFile({ localUri, mimeType });
       if (onSuccess) onSuccess();
       return;
     }
-
-    const MediaLibrary = require('expo-media-library') as typeof import('expo-media-library');
-    const perm = await MediaLibrary.requestPermissionsAsync();
-    if (!perm.granted) {
-      if (onPermissionDenied) onPermissionDenied();
-      else Alert.alert('Permission required', 'Please allow photo library access to save media.');
-      return;
-    }
-
-    // Handle data URIs.
-    if (url.startsWith('data:')) {
-      const comma = url.indexOf(',');
-      if (comma < 0) throw new Error('Invalid data URI');
-      const header = url.slice(0, comma);
-      const b64 = url.slice(comma + 1);
-      const isBase64 = /;base64/i.test(header);
-      if (!isBase64) throw new Error('Unsupported data URI encoding');
-
-      const fsMod: unknown = require('expo-file-system');
-      const fs: ExpoFileSystemLike = isRecord(fsMod) ? (fsMod as ExpoFileSystemLike) : {};
-      const root = fs.Paths?.cache ?? fs.Paths?.document;
-      if (!root) throw new Error('No writable cache directory');
-      const File = fs.File;
-      if (!File) throw new Error('File API not available');
-      // Put the "real" filename at the leaf so Photos/Gallery has the best chance to preserve it.
-      const subdir = `${root.replace(/\/+$/, '')}/${uniqueDir}`;
-      if (typeof fs.makeDirectoryAsync === 'function') {
-        await fs.makeDirectoryAsync(subdir, { intermediates: true }).catch(() => {});
-      }
-      const dest = new File(subdir, downloadName);
-      if (typeof dest.write !== 'function') throw new Error('File write API not available');
-      await ensureEmptyDest(fs, dest.uri);
-      await dest.write(b64, { encoding: 'base64' });
-      await MediaLibrary.saveToLibraryAsync(dest.uri);
-      if (onSuccess) onSuccess();
-      else if (Platform.OS === 'android') ToastAndroid.show('Saved to Photos', ToastAndroid.SHORT);
-      return;
-    }
-
-    // If it's already a local file, save it directly.
-    if (url.startsWith('file:')) {
-      await MediaLibrary.saveToLibraryAsync(url);
-      if (onSuccess) onSuccess();
-      else if (Platform.OS === 'android') ToastAndroid.show('Saved to Photos', ToastAndroid.SHORT);
-      return;
-    }
-
-    // Modern Expo FileSystem API (SDK 54+).
-    const fsMod: unknown = require('expo-file-system');
-    const fs: ExpoFileSystemLike = isRecord(fsMod) ? (fsMod as ExpoFileSystemLike) : {};
-    const root = fs.Paths?.cache ?? fs.Paths?.document;
-    if (!root) throw new Error('No writable cache directory');
-    const File = fs.File;
-    if (!File) throw new Error('File API not available');
-    // Put the "real" filename at the leaf so Photos/Gallery has the best chance to preserve it.
-    const subdir = `${root.replace(/\/+$/, '')}/${uniqueDir}`;
-    if (typeof fs.makeDirectoryAsync === 'function') {
-      await fs.makeDirectoryAsync(subdir, { intermediates: true }).catch(() => {});
-    }
-    const dest = new File(subdir, downloadName);
-    await ensureEmptyDest(fs, dest.uri);
-
-    // The docs support either instance or static download; support both for safety.
-    if (typeof dest?.downloadFileAsync === 'function') {
-      await dest.downloadFileAsync(url);
-    } else if (typeof File?.downloadFileAsync === 'function') {
-      await File.downloadFileAsync(url, dest);
-    } else {
-      throw new Error('File download API not available');
-    }
-
-    await MediaLibrary.saveToLibraryAsync(dest.uri);
-    if (onSuccess) onSuccess();
-    else if (Platform.OS === 'android') ToastAndroid.show('Saved to Photos', ToastAndroid.SHORT);
+    throw new Error(`Unsupported save path for platform ${Platform.OS}`);
   } catch (e: unknown) {
     const msg = getErrorMessage(e) || 'Could not save attachment';
     // Avoid noisy errors when a user closes the system share sheet.


### PR DESCRIPTION
Many issues with iOS having stacked modals causing app to be unresponsive to touch.

Padding below text entry and onscreen keyboard for ios

Remove fixed height to TextInput to allow iOS textinput to grow dynamically

Change Settings Modal to View to prevent conflict with uiPrompt modals.

Fix IOS padding without native keyboard

Fix members modal to View to prevent nested modals

Remove toast on ios for channel public/private change causing nested modal lock

Fix saving media due to filepath on ios

Channels in settings is a View to avoid nested modals

Create passphrase placeholder fixed on ios

ios shows a toast for copying a message from message options

Make Blocklist a view to prevent nested modals

Keyboard.dismiss() on useMessageActionMenu to ensure native ios keyboard dismisses when message options opened. Android/web did this automatically already, but the code is platform agnostic for this

ALL PLATFORMS:
Shorten Submit Lengths with Animated Dots on Recovery flows causing an overflowing submit status button

Show Copied on AI Helper when copying a selection from the Copy button

Editor cancels out when changing active conversation

UI Polish on Change Image/Remove Image on Background

harden fetching a public key on backend 

Fix options on Select being cut off on narrower screens