### PR TITLE
Evan perry/ios darkmode slider

### DIFF
--- a/frontend/App.styles.ts
+++ b/frontend/App.styles.ts
@@ -124,7 +124,9 @@ export const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 8,
-    paddingHorizontal: 10,
+    // Same horizontal inset as HeaderMenuModal row labels (row.paddingHorizontal = 12).
+    paddingLeft: 12,
+    paddingRight: 8,
     paddingVertical: 6,
     borderRadius: 10,
     backgroundColor: APP_COLORS.light.bg.app,
@@ -135,7 +137,7 @@ export const styles = StyleSheet.create({
     backgroundColor: APP_COLORS.dark.bg.surface,
     borderColor: APP_COLORS.dark.border.subtle,
   },
-  // Web-only: avoid browser default teal/blue accent that can bleed into the native Switch implementation.
+  // Web + iOS: custom toggle (Android uses native Switch). Avoids native UISwitch thumb sizing quirks.
   webToggleTrack: {
     width: 44,
     height: 26,
@@ -153,11 +155,9 @@ export const styles = StyleSheet.create({
     height: 22,
     borderRadius: 999,
     backgroundColor: APP_COLORS.light.bg.app,
-    transform: [{ translateX: 0 }],
   },
   webToggleThumbOn: {
     backgroundColor: PALETTE.slate750,
-    transform: [{ translateX: 18 }],
   },
   menuIconBtn: {
     width: 40,

--- a/frontend/src/components/HeaderMenuModal.tsx
+++ b/frontend/src/components/HeaderMenuModal.tsx
@@ -105,7 +105,11 @@ export function HeaderMenuModal({
   const cardContent = (
     <>
       <View style={styles.topRightCloseRow}>
-        {headerRight ? <View style={styles.headerRightSlot}>{headerRight}</View> : null}
+        {headerRight ? (
+          <View style={styles.headerLeftSlot}>
+            <View style={styles.headerRightSlot}>{headerRight}</View>
+          </View>
+        ) : null}
         <Pressable
           onPress={onClose}
           style={({ pressed }) => [
@@ -300,11 +304,21 @@ const styles = StyleSheet.create({
   },
   topRightCloseRow: {
     flexDirection: 'row',
-    justifyContent: 'flex-end',
+    justifyContent: 'space-between',
     alignItems: 'center',
     paddingTop: 8,
     paddingHorizontal: 8,
     gap: 8,
+  },
+  // Match list layout: list padding 8, then row paddingHorizontal 12 (same as styles.row).
+  // Left slot starts at 8px (same as row Pressable); ThemeToggle adds its own paddingLeft 12 so the
+  // sun lines up with "Chats" / "Channels" label text (8 + 12 = 20px from card).
+  headerLeftSlot: {
+    flex: 1,
+    minWidth: 0,
+    paddingLeft: 0,
+    alignItems: 'flex-start',
+    justifyContent: 'center',
   },
   headerRightSlot: { flexDirection: 'row', alignItems: 'center' },
   closeIconBtn: {

--- a/frontend/src/components/ThemeToggleRow.tsx
+++ b/frontend/src/components/ThemeToggleRow.tsx
@@ -1,9 +1,12 @@
 import Feather from '@expo/vector-icons/Feather';
 import React from 'react';
 import type { StyleProp, ViewStyle } from 'react-native';
-import { Platform, Pressable, Switch, View } from 'react-native';
+import { Animated, Easing, Platform, Pressable, Switch, View } from 'react-native';
 
 import { APP_COLORS } from '../theme/colors';
+
+/** Horizontal travel for custom toggle thumb (track inner width minus thumb). */
+const WEB_TOGGLE_THUMB_TRAVEL_PX = 18;
 
 export type ThemeToggleRowStyles = {
   themeToggle: StyleProp<ViewStyle>;
@@ -13,6 +16,37 @@ export type ThemeToggleRowStyles = {
   webToggleThumb: StyleProp<ViewStyle>;
   webToggleThumbOn?: StyleProp<ViewStyle>;
 };
+
+function AnimatedCustomToggleThumb({
+  isDark,
+  styles,
+}: {
+  isDark: boolean;
+  styles: ThemeToggleRowStyles;
+}): React.JSX.Element {
+  const slide = React.useRef(
+    new Animated.Value(isDark ? WEB_TOGGLE_THUMB_TRAVEL_PX : 0),
+  ).current;
+
+  React.useEffect(() => {
+    Animated.timing(slide, {
+      toValue: isDark ? WEB_TOGGLE_THUMB_TRAVEL_PX : 0,
+      duration: 240,
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: true,
+    }).start();
+  }, [isDark, slide]);
+
+  return (
+    <Animated.View
+      style={[
+        styles.webToggleThumb,
+        isDark ? styles.webToggleThumbOn : null,
+        { transform: [{ translateX: slide }] },
+      ]}
+    />
+  );
+}
 
 export function ThemeToggleRow({
   isDark,
@@ -24,23 +58,18 @@ export function ThemeToggleRow({
   styles: ThemeToggleRowStyles;
 }): React.JSX.Element {
   return (
-    <View
-      style={[
-        styles.themeToggle,
-        isDark && styles.themeToggleDark,
-        // iOS: native Switch is larger; use tighter padding so row fits and left padding can show.
-        Platform.OS === 'ios' && { paddingHorizontal: 6, marginLeft: 8 },
-      ]}
-    >
+    <View style={[styles.themeToggle, isDark && styles.themeToggleDark]}>
       <Feather
         name={isDark ? 'moon' : 'sun'}
         size={16}
         color={isDark ? APP_COLORS.dark.text.primary : APP_COLORS.light.text.primary}
       />
-      {Platform.OS === 'web' ? (
+      {/* Web + iOS: custom track + circle thumb. Native UISwitch thumb can look oversized on recent iOS. */}
+      {Platform.OS === 'web' || Platform.OS === 'ios' ? (
         <Pressable
           onPress={() => onSetTheme(isDark ? 'light' : 'dark')}
-          accessibilityRole="button"
+          accessibilityRole="switch"
+          accessibilityState={{ checked: isDark }}
           accessibilityLabel="Toggle theme"
           style={({ pressed }) => [
             styles.webToggleTrack,
@@ -48,7 +77,7 @@ export function ThemeToggleRow({
             pressed ? { opacity: 0.9 } : null,
           ]}
         >
-          <View style={[styles.webToggleThumb, isDark ? styles.webToggleThumbOn : null]} />
+          <AnimatedCustomToggleThumb isDark={isDark} styles={styles} />
         </Pressable>
       ) : (
         <Switch

--- a/frontend/src/components/ThemeToggleRow.tsx
+++ b/frontend/src/components/ThemeToggleRow.tsx
@@ -24,9 +24,7 @@ function AnimatedCustomToggleThumb({
   isDark: boolean;
   styles: ThemeToggleRowStyles;
 }): React.JSX.Element {
-  const slide = React.useRef(
-    new Animated.Value(isDark ? WEB_TOGGLE_THUMB_TRAVEL_PX : 0),
-  ).current;
+  const slide = React.useRef(new Animated.Value(isDark ? WEB_TOGGLE_THUMB_TRAVEL_PX : 0)).current;
 
   React.useEffect(() => {
     Animated.timing(slide, {

--- a/frontend/src/components/__tests__/ThemeToggleRow.test.tsx
+++ b/frontend/src/components/__tests__/ThemeToggleRow.test.tsx
@@ -14,7 +14,7 @@ jest.mock('@expo/vector-icons/Feather', () => {
   };
 });
 
-type PlatformOS = 'ios' | 'web';
+type PlatformOS = 'ios' | 'android' | 'web';
 
 function withPlatformOS<T>(os: PlatformOS, run: () => T): T {
   const originalOS = Platform.OS;

--- a/frontend/src/components/__tests__/ThemeToggleRow.test.tsx
+++ b/frontend/src/components/__tests__/ThemeToggleRow.test.tsx
@@ -38,8 +38,8 @@ beforeEach(() => {
 });
 
 describe('ThemeToggleRow (native branch)', () => {
-  test('renders a Switch and maps value changes to onSetTheme', () => {
-    withPlatformOS('ios', () => {
+  test('Android: renders Switch and maps value changes to onSetTheme', () => {
+    withPlatformOS('android', () => {
       const onSetTheme = jest.fn();
 
       const screen = render(
@@ -48,6 +48,21 @@ describe('ThemeToggleRow (native branch)', () => {
 
       const sw = screen.UNSAFE_getByType(Switch);
       sw.props.onValueChange(true);
+
+      expect(onSetTheme).toHaveBeenCalledTimes(1);
+      expect(onSetTheme).toHaveBeenCalledWith('dark');
+    });
+  });
+
+  test('iOS: custom toggle press maps to onSetTheme', () => {
+    withPlatformOS('ios', () => {
+      const onSetTheme = jest.fn();
+
+      const screen = render(
+        <ThemeToggleRow isDark={false} onSetTheme={onSetTheme} styles={styles} />,
+      );
+
+      fireEvent.press(screen.getByLabelText('Toggle theme'));
 
       expect(onSetTheme).toHaveBeenCalledTimes(1);
       expect(onSetTheme).toHaveBeenCalledWith('dark');

--- a/frontend/src/features/appShell/hooks/useDeleteAccountFlow.ts
+++ b/frontend/src/features/appShell/hooks/useDeleteAccountFlow.ts
@@ -99,7 +99,7 @@ export function useDeleteAccountFlow({
       onSignedOut?.();
     }
 
-    await promptAlert('Account deleted', 'Your account deletion request completed.');
+    await promptAlert('Account Deleted', 'Your account deletion request completed.');
   }, [
     apiUrl,
     deleteUser,

--- a/frontend/src/features/chat/components/DmSettingsPanel.tsx
+++ b/frontend/src/features/chat/components/DmSettingsPanel.tsx
@@ -107,143 +107,209 @@ export function DmSettingsPanel({
   return (
     <>
       {isDm ? (
-        <View style={styles.dmSettingsRow}>
-          <View style={styles.dmSettingSlotLeft}>
-            <View style={styles.dmSettingGroup}>
-              <Text
-                style={[
-                  styles.decryptLabel,
-                  isDark ? styles.decryptLabelDark : null,
-                  styles.dmSettingLabel,
-                  compact ? styles.dmSettingLabelCompact : null,
-                ]}
-                numberOfLines={1}
-              >
-                Auto‑Decrypt
-              </Text>
-              {compact ? (
-                <MiniToggle
-                  value={autoDecrypt}
-                  onValueChange={onToggleAutoDecrypt}
-                  disabled={!myPrivateKeyReady}
-                  isDark={isDark}
-                  styles={styles}
-                />
-              ) : Platform.OS === 'web' ? (
-                <MiniToggle
-                  value={autoDecrypt}
-                  onValueChange={onToggleAutoDecrypt}
-                  disabled={!myPrivateKeyReady}
-                  isDark={isDark}
-                  styles={styles}
-                />
-              ) : Platform.OS === 'ios' ? (
-                <MiniToggle
-                  value={autoDecrypt}
-                  onValueChange={onToggleAutoDecrypt}
-                  disabled={!myPrivateKeyReady}
-                  isDark={isDark}
-                  styles={styles}
-                />
-              ) : (
-                <Switch
-                  value={autoDecrypt}
-                  onValueChange={onToggleAutoDecrypt}
-                  disabled={!myPrivateKeyReady}
-                  trackColor={{
-                    false: APP_COLORS.light.border.default,
-                    true: APP_COLORS.light.border.default,
-                  }}
-                  thumbColor={isDark ? APP_COLORS.dark.border.subtle : APP_COLORS.light.bg.app}
-                  ios_backgroundColor={APP_COLORS.light.border.default}
-                />
-              )}
-            </View>
-          </View>
-
-          <View style={styles.dmSettingSlotCenter}>
-            <View style={styles.dmSettingGroup}>
-              <Text
-                style={[
-                  styles.decryptLabel,
-                  isDark ? styles.decryptLabelDark : null,
-                  styles.dmSettingLabel,
-                  compact ? styles.dmSettingLabelCompact : null,
-                ]}
-                numberOfLines={1}
-              >
-                Self‑Destruct
-              </Text>
-              <Pressable
-                style={[
-                  styles.ttlChip,
-                  isDark ? styles.ttlChipDark : null,
-                  compact ? styles.ttlChipCompact : null,
-                ]}
-                onPress={onOpenTtlPicker}
-              >
+        compact ? (
+          <View
+            style={[
+              styles.dmSettingsRow,
+              { flexDirection: 'column', alignItems: 'stretch', gap: 6 },
+            ]}
+          >
+            <View
+              style={{
+                width: '100%',
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'flex-start',
+                columnGap: 14,
+              }}
+            >
+              <View style={[styles.dmSettingGroup, { minWidth: 0 }]}>
                 <Text
                   style={[
-                    styles.ttlChipText,
-                    isDark ? styles.ttlChipTextDark : null,
-                    String(ttlLabel).trim().toLowerCase() === 'off' ? styles.ttlChipTextOff : null,
+                    styles.decryptLabel,
+                    isDark ? styles.decryptLabelDark : null,
+                    styles.dmSettingLabel,
+                    styles.dmSettingLabelCompact,
                   ]}
+                  numberOfLines={1}
                 >
-                  {ttlLabel}
+                  Auto‑Decrypt
                 </Text>
-              </Pressable>
+                <MiniToggle
+                  value={autoDecrypt}
+                  onValueChange={onToggleAutoDecrypt}
+                  disabled={!myPrivateKeyReady}
+                  isDark={isDark}
+                  styles={styles}
+                />
+              </View>
+              <View style={[styles.dmSettingGroup, { minWidth: 0, marginLeft: 'auto' }]}>
+                <Text
+                  style={[
+                    styles.decryptLabel,
+                    isDark ? styles.decryptLabelDark : null,
+                    styles.dmSettingLabel,
+                    styles.dmSettingLabelCompact,
+                  ]}
+                  numberOfLines={1}
+                >
+                  Self‑Destruct
+                </Text>
+                <Pressable
+                  style={[
+                    styles.ttlChip,
+                    isDark ? styles.ttlChipDark : null,
+                    styles.ttlChipCompact,
+                  ]}
+                  onPress={onOpenTtlPicker}
+                >
+                  <Text
+                    style={[
+                      styles.ttlChipText,
+                      isDark ? styles.ttlChipTextDark : null,
+                      String(ttlLabel).trim().toLowerCase() === 'off'
+                        ? styles.ttlChipTextOff
+                        : null,
+                    ]}
+                  >
+                    {ttlLabel}
+                  </Text>
+                </Pressable>
+              </View>
+            </View>
+            <View
+              style={{
+                width: '100%',
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'flex-end',
+              }}
+            >
+              <View style={[styles.dmSettingGroup, { minWidth: 0 }]}>
+                <Text
+                  style={[
+                    styles.decryptLabel,
+                    isDark ? styles.decryptLabelDark : null,
+                    styles.dmSettingLabel,
+                    styles.dmSettingLabelCompact,
+                  ]}
+                  numberOfLines={1}
+                >
+                  Read Receipts
+                </Text>
+                <MiniToggle
+                  value={sendReadReceipts}
+                  isDark={isDark}
+                  styles={styles}
+                  onValueChange={onToggleReadReceipts}
+                />
+              </View>
             </View>
           </View>
+        ) : (
+          <View style={styles.dmSettingsRow}>
+            <View style={styles.dmSettingSlotLeft}>
+              <View style={styles.dmSettingGroup}>
+                <Text
+                  style={[
+                    styles.decryptLabel,
+                    isDark ? styles.decryptLabelDark : null,
+                    styles.dmSettingLabel,
+                  ]}
+                  numberOfLines={1}
+                >
+                  Auto‑Decrypt
+                </Text>
+                {Platform.OS === 'web' || Platform.OS === 'ios' ? (
+                  <MiniToggle
+                    value={autoDecrypt}
+                    onValueChange={onToggleAutoDecrypt}
+                    disabled={!myPrivateKeyReady}
+                    isDark={isDark}
+                    styles={styles}
+                  />
+                ) : (
+                  <Switch
+                    value={autoDecrypt}
+                    onValueChange={onToggleAutoDecrypt}
+                    disabled={!myPrivateKeyReady}
+                    trackColor={{
+                      false: APP_COLORS.light.border.default,
+                      true: APP_COLORS.light.border.default,
+                    }}
+                    thumbColor={isDark ? APP_COLORS.dark.border.subtle : APP_COLORS.light.bg.app}
+                    ios_backgroundColor={APP_COLORS.light.border.default}
+                  />
+                )}
+              </View>
+            </View>
 
-          <View style={styles.dmSettingSlotRight}>
-            <View style={styles.dmSettingGroup}>
-              <Text
-                style={[
-                  styles.decryptLabel,
-                  isDark ? styles.decryptLabelDark : null,
-                  styles.dmSettingLabel,
-                  compact ? styles.dmSettingLabelCompact : null,
-                ]}
-                numberOfLines={1}
-              >
-                Read Receipts
-              </Text>
-              {compact ? (
-                <MiniToggle
-                  value={sendReadReceipts}
-                  isDark={isDark}
-                  styles={styles}
-                  onValueChange={onToggleReadReceipts}
-                />
-              ) : Platform.OS === 'web' ? (
-                <MiniToggle
-                  value={sendReadReceipts}
-                  isDark={isDark}
-                  styles={styles}
-                  onValueChange={onToggleReadReceipts}
-                />
-              ) : Platform.OS === 'ios' ? (
-                <MiniToggle
-                  value={sendReadReceipts}
-                  isDark={isDark}
-                  styles={styles}
-                  onValueChange={onToggleReadReceipts}
-                />
-              ) : (
-                <Switch
-                  value={sendReadReceipts}
-                  onValueChange={onToggleReadReceipts}
-                  trackColor={{
-                    false: APP_COLORS.light.border.default,
-                    true: APP_COLORS.light.border.default,
-                  }}
-                  thumbColor={isDark ? APP_COLORS.dark.border.subtle : APP_COLORS.light.bg.app}
-                  ios_backgroundColor={APP_COLORS.light.border.default}
-                />
-              )}
+            <View style={styles.dmSettingSlotCenter}>
+              <View style={styles.dmSettingGroup}>
+                <Text
+                  style={[
+                    styles.decryptLabel,
+                    isDark ? styles.decryptLabelDark : null,
+                    styles.dmSettingLabel,
+                  ]}
+                  numberOfLines={1}
+                >
+                  Self‑Destruct
+                </Text>
+                <Pressable
+                  style={[styles.ttlChip, isDark ? styles.ttlChipDark : null]}
+                  onPress={onOpenTtlPicker}
+                >
+                  <Text
+                    style={[
+                      styles.ttlChipText,
+                      isDark ? styles.ttlChipTextDark : null,
+                      String(ttlLabel).trim().toLowerCase() === 'off'
+                        ? styles.ttlChipTextOff
+                        : null,
+                    ]}
+                  >
+                    {ttlLabel}
+                  </Text>
+                </Pressable>
+              </View>
+            </View>
+
+            <View style={styles.dmSettingSlotRight}>
+              <View style={styles.dmSettingGroup}>
+                <Text
+                  style={[
+                    styles.decryptLabel,
+                    isDark ? styles.decryptLabelDark : null,
+                    styles.dmSettingLabel,
+                  ]}
+                  numberOfLines={1}
+                >
+                  Read Receipts
+                </Text>
+                {Platform.OS === 'web' || Platform.OS === 'ios' ? (
+                  <MiniToggle
+                    value={sendReadReceipts}
+                    isDark={isDark}
+                    styles={styles}
+                    onValueChange={onToggleReadReceipts}
+                  />
+                ) : (
+                  <Switch
+                    value={sendReadReceipts}
+                    onValueChange={onToggleReadReceipts}
+                    trackColor={{
+                      false: APP_COLORS.light.border.default,
+                      true: APP_COLORS.light.border.default,
+                    }}
+                    thumbColor={isDark ? APP_COLORS.dark.border.subtle : APP_COLORS.light.bg.app}
+                    ios_backgroundColor={APP_COLORS.light.border.default}
+                  />
+                )}
+              </View>
             </View>
           </View>
-        </View>
+        )
       ) : null}
 
       {isGroup ? (

--- a/frontend/src/features/chat/components/DmSettingsPanel.tsx
+++ b/frontend/src/features/chat/components/DmSettingsPanel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Platform, Pressable, Switch, Text, View } from 'react-native';
+import { Animated, Easing, Platform, Pressable, Switch, Text, View } from 'react-native';
 
 import type { ChatScreenStyles } from '../../../screens/ChatScreen.styles';
 import { APP_COLORS } from '../../../theme/colors';
@@ -17,12 +17,24 @@ function MiniToggle({
   isDark: boolean;
   styles: ChatScreenStyles;
 }): React.JSX.Element {
+  const slide = React.useRef(new Animated.Value(value ? 10 : 0)).current;
+
+  React.useEffect(() => {
+    Animated.timing(slide, {
+      toValue: value ? 10 : 0,
+      duration: 180,
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: true,
+    }).start();
+  }, [slide, value]);
+
   return (
     <Pressable
       onPress={() => {
         if (disabled) return;
         onValueChange(!value);
       }}
+      hitSlop={{ top: 8, bottom: 8, left: 10, right: 10 }}
       accessibilityRole="switch"
       accessibilityState={{ checked: value, disabled: !!disabled }}
       style={({ pressed }) => [
@@ -34,11 +46,11 @@ function MiniToggle({
         pressed && !disabled ? styles.miniTogglePressed : null,
       ]}
     >
-      <View
+      <Animated.View
         style={[
           styles.miniToggleThumb,
           isDark ? styles.miniToggleThumbDark : null,
-          value ? styles.miniToggleThumbOn : null,
+          { transform: [{ translateX: slide }] },
         ]}
       />
     </Pressable>
@@ -125,6 +137,14 @@ export function DmSettingsPanel({
                   isDark={isDark}
                   styles={styles}
                 />
+              ) : Platform.OS === 'ios' ? (
+                <MiniToggle
+                  value={autoDecrypt}
+                  onValueChange={onToggleAutoDecrypt}
+                  disabled={!myPrivateKeyReady}
+                  isDark={isDark}
+                  styles={styles}
+                />
               ) : (
                 <Switch
                   value={autoDecrypt}
@@ -196,6 +216,13 @@ export function DmSettingsPanel({
                   onValueChange={onToggleReadReceipts}
                 />
               ) : Platform.OS === 'web' ? (
+                <MiniToggle
+                  value={sendReadReceipts}
+                  isDark={isDark}
+                  styles={styles}
+                  onValueChange={onToggleReadReceipts}
+                />
+              ) : Platform.OS === 'ios' ? (
                 <MiniToggle
                   value={sendReadReceipts}
                   isDark={isDark}

--- a/frontend/src/features/chat/components/ReportModal.tsx
+++ b/frontend/src/features/chat/components/ReportModal.tsx
@@ -1,6 +1,8 @@
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import React from 'react';
 import {
+  Animated,
+  Easing,
   Image,
   Modal,
   Platform,
@@ -40,6 +42,7 @@ import {
 import type { ChatMessage } from '../types';
 
 type ReportNotice = { type: 'success' | 'error'; message: string };
+const MINI_TOGGLE_THUMB_TRAVEL_PX = 10;
 
 function MiniToggle({
   value,
@@ -54,12 +57,23 @@ function MiniToggle({
   isDark: boolean;
   styles: ChatScreenStyles;
 }): React.JSX.Element {
+  const slide = React.useRef(new Animated.Value(value ? MINI_TOGGLE_THUMB_TRAVEL_PX : 0)).current;
+  React.useEffect(() => {
+    Animated.timing(slide, {
+      toValue: value ? MINI_TOGGLE_THUMB_TRAVEL_PX : 0,
+      duration: 180,
+      easing: Easing.out(Easing.cubic),
+      useNativeDriver: true,
+    }).start();
+  }, [slide, value]);
+
   return (
     <Pressable
       onPress={() => {
         if (disabled) return;
         onValueChange(!value);
       }}
+      hitSlop={{ top: 8, bottom: 8, left: 10, right: 10 }}
       accessibilityRole="switch"
       accessibilityState={{ checked: value, disabled: !!disabled }}
       style={({ pressed }) => [
@@ -71,11 +85,11 @@ function MiniToggle({
         pressed && !disabled ? styles.miniTogglePressed : null,
       ]}
     >
-      <View
+      <Animated.View
         style={[
           styles.miniToggleThumb,
           isDark ? styles.miniToggleThumbDark : null,
-          value ? styles.miniToggleThumbOn : null,
+          { transform: [{ translateX: slide }] },
         ]}
       />
     </Pressable>
@@ -254,15 +268,7 @@ export function ReportModal({
                 >
                   Message
                 </Text>
-                {Platform.OS === 'web' ? (
-                  <MiniToggle
-                    value={reportKind === 'user'}
-                    disabled={submitting}
-                    isDark={isDark}
-                    styles={styles}
-                    onValueChange={onToggleKind}
-                  />
-                ) : (
+                {Platform.OS === 'android' ? (
                   <Switch
                     value={reportKind === 'user'}
                     disabled={submitting}
@@ -272,6 +278,14 @@ export function ReportModal({
                       true: APP_COLORS.light.border.default,
                     }}
                     thumbColor={isDark ? APP_COLORS.dark.border.subtle : APP_COLORS.light.bg.app}
+                  />
+                ) : (
+                  <MiniToggle
+                    value={reportKind === 'user'}
+                    disabled={submitting}
+                    isDark={isDark}
+                    styles={styles}
+                    onValueChange={onToggleKind}
                   />
                 )}
                 <Text

--- a/frontend/src/screens/GuestGlobalScreen.styles.ts
+++ b/frontend/src/screens/GuestGlobalScreen.styles.ts
@@ -50,7 +50,8 @@ export const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 8,
-    paddingHorizontal: 10,
+    paddingLeft: 12,
+    paddingRight: 8,
     paddingVertical: 6,
     borderRadius: 10,
     backgroundColor: APP_COLORS.light.bg.app,
@@ -61,7 +62,7 @@ export const styles = StyleSheet.create({
     backgroundColor: APP_COLORS.dark.bg.surface,
     borderColor: APP_COLORS.dark.border.subtle,
   },
-  // Web-only: avoid browser default teal/blue accent that can bleed into the native Switch implementation.
+  // Web + iOS: custom toggle (Android uses native Switch).
   webToggleTrack: {
     width: 44,
     height: 26,
@@ -79,11 +80,9 @@ export const styles = StyleSheet.create({
     height: 22,
     borderRadius: 999,
     backgroundColor: APP_COLORS.light.bg.app,
-    transform: [{ translateX: 0 }],
   },
   webToggleThumbOn: {
     backgroundColor: APP_COLORS.dark.border.subtle,
-    transform: [{ translateX: 18 }],
   },
   menuIconBtn: {
     width: 40,


### PR DESCRIPTION
Fix styling of dark mode toggle on ios to match web/android

Fix report toggle on ios

Improve animated toggle for read receipts and auto-decrypt toggles on ios

Allow additional DM options to wrap to new line instead of truncate on small ios screens.