### PR TITLE
Fix nested modal from leave chat confirmation

### DIFF
--- a/frontend/src/features/appShell/components/MainAppChatsAndRecoveryModals.tsx
+++ b/frontend/src/features/appShell/components/MainAppChatsAndRecoveryModals.tsx
@@ -66,13 +66,21 @@ export function MainAppChatsAndRecoveryModals({
     unreadCount?: number;
   }>;
   goToConversation: (conversationId: string) => void;
-  deleteConversationFromList: (conversationId: string) => void | Promise<void>;
+  deleteConversationFromList: (
+    conversationId: string,
+    opts?: { skipConfirm?: boolean },
+  ) => void | Promise<void>;
   formatChatActivityDate: (ts: number) => string;
 }): React.JSX.Element {
   const recoveryKb = useKeyboardOverlap({ enabled: recoveryOpen });
   const chatsKb = useKeyboardOverlap({ enabled: chatsOpen });
   const [recoverySheetHeight, setRecoverySheetHeight] = React.useState<number>(0);
   const [chatsSheetHeight, setChatsSheetHeight] = React.useState<number>(0);
+  const [deleteChatIosPrompt, setDeleteChatIosPrompt] = React.useState<null | {
+    conversationId: string;
+    label: string;
+  }>(null);
+  const [deleteChatIosBusy, setDeleteChatIosBusy] = React.useState<boolean>(false);
   const recoveryBottomPad = React.useMemo(
     () =>
       calcCenteredModalBottomPadding(
@@ -225,9 +233,14 @@ export function MainAppChatsAndRecoveryModals({
                     </View>
                   ) : null}
                   <Pressable
-                    onPress={() =>
-                      void Promise.resolve(deleteConversationFromList(t.conversationId))
-                    }
+                    onPress={() => {
+                      if (Platform.OS === 'ios') {
+                        const label = String(t.peer || 'Direct Message').trim() || 'Direct Message';
+                        setDeleteChatIosPrompt({ conversationId: t.conversationId, label });
+                        return;
+                      }
+                      void Promise.resolve(deleteConversationFromList(t.conversationId));
+                    }}
                     style={({ pressed }) => [
                       styles.chatDeleteBtn,
                       isDark ? styles.chatDeleteBtnDark : null,
@@ -266,6 +279,65 @@ export function MainAppChatsAndRecoveryModals({
           </Pressable>
         </View>
       </View>
+      {Platform.OS === 'ios' && deleteChatIosPrompt ? (
+        <View
+          style={[
+            StyleSheet.absoluteFillObject,
+            styles.modalOverlay,
+            { zIndex: 1000, elevation: 1000 },
+          ]}
+        >
+          <Pressable style={StyleSheet.absoluteFill} onPress={() => setDeleteChatIosPrompt(null)} />
+          <View style={[styles.modalContent, isDark ? styles.modalContentDark : null]}>
+            <Text style={[styles.modalTitle, isDark ? styles.modalTitleDark : null]}>
+              Remove chat?
+            </Text>
+            <Text style={[styles.modalHelperText, isDark ? styles.modalHelperTextDark : null]}>
+              {`Remove "${deleteChatIosPrompt.label}" from your Chats list? If they message you again, it will reappear.\n\nThis does not delete message history.`}
+            </Text>
+            <View style={styles.modalButtons}>
+              <Pressable
+                style={[
+                  styles.modalButton,
+                  styles.modalButtonCta,
+                  isDark ? styles.modalButtonCtaDark : null,
+                  deleteChatIosBusy ? { opacity: 0.5 } : null,
+                ]}
+                disabled={deleteChatIosBusy}
+                onPress={() => {
+                  if (deleteChatIosBusy) return;
+                  const target = deleteChatIosPrompt;
+                  if (!target) return;
+                  setDeleteChatIosBusy(true);
+                  void Promise.resolve(
+                    deleteConversationFromList(target.conversationId, { skipConfirm: true }),
+                  ).finally(() => {
+                    setDeleteChatIosBusy(false);
+                    setDeleteChatIosPrompt(null);
+                  });
+                }}
+              >
+                <Text style={[styles.modalButtonText, styles.modalButtonCtaText]}>
+                  {deleteChatIosBusy ? 'Removing' : 'Remove'}
+                </Text>
+              </Pressable>
+              <Pressable
+                style={[
+                  styles.modalButton,
+                  isDark ? styles.modalButtonDark : null,
+                  deleteChatIosBusy ? { opacity: 0.5 } : null,
+                ]}
+                disabled={deleteChatIosBusy}
+                onPress={() => setDeleteChatIosPrompt(null)}
+              >
+                <Text style={[styles.modalButtonText, isDark ? styles.modalButtonTextDark : null]}>
+                  Cancel
+                </Text>
+              </Pressable>
+            </View>
+          </View>
+        </View>
+      ) : null}
     </View>
   );
 

--- a/frontend/src/features/appShell/components/MainAppContent.tsx
+++ b/frontend/src/features/appShell/components/MainAppContent.tsx
@@ -651,15 +651,25 @@ export const MainAppContent = ({
     }
     const v = String(lastDmConversationIdRef.current || '').trim();
     if (v.startsWith('dm#') || v.startsWith('gdm#')) {
-      goToConversation(v);
-      return;
+      const existsInChats = chatsList.some((c) => String(c.conversationId || '').trim() === v);
+      if (existsInChats) {
+        goToConversation(v);
+        return;
+      }
+      // Stale pointer (e.g. user removed/left that DM). Clear persisted "last DM" and fallback to Start DM.
+      lastDmConversationIdRef.current = '';
+      void AsyncStorage.removeItem('ui:lastDmConversationId').catch(() => {});
+      const userKey = myUserSub ? `ui:lastDmConversationId:${myUserSub}` : '';
+      if (userKey) void AsyncStorage.removeItem(userKey).catch(() => {});
     }
     // First-time / no last DM: fallback to showing Enter Names row.
     setSearchOpen(true);
   }, [
+    chatsList,
     goToConversation,
     isDmMode,
     lastDmConversationIdRef,
+    myUserSub,
     setPeerInput,
     setSearchError,
     setSearchOpen,

--- a/frontend/src/features/appShell/hooks/useChatsInboxData.ts
+++ b/frontend/src/features/appShell/hooks/useChatsInboxData.ts
@@ -29,6 +29,11 @@ export type ChatsListEntry = {
   unreadCount: number;
 };
 
+function isDmLikeConversationId(conversationId: string): boolean {
+  const id = String(conversationId || '').trim();
+  return id.startsWith('dm#') || id.startsWith('gdm#');
+}
+
 export function useChatsInboxData({
   apiUrl,
   fetchAuthSession,
@@ -239,7 +244,13 @@ export function useChatsInboxData({
           count,
         };
         const lastAt = Number(it.lastMessageCreatedAt || 0);
-        upsertDmThread(convId, sender, Number.isFinite(lastAt) && lastAt > 0 ? lastAt : Date.now());
+        if (isDmLikeConversationId(convId)) {
+          upsertDmThread(
+            convId,
+            sender,
+            Number.isFinite(lastAt) && lastAt > 0 ? lastAt : Date.now(),
+          );
+        }
       }
       setUnreadDmMap((prev) => {
         // Prefer freshly fetched unread info, but apply any local group title overrides
@@ -256,6 +267,7 @@ export function useChatsInboxData({
     const mapUnread = unreadDmMap;
     if (serverConversations.length) {
       return serverConversations
+        .filter((c) => isDmLikeConversationId(c.conversationId))
         .map((c) => ({
           conversationId: c.conversationId,
           peer: c.peerDisplayName || mapUnread[c.conversationId]?.user || 'Direct Message',
@@ -266,7 +278,7 @@ export function useChatsInboxData({
         }))
         .sort((a, b) => (b.lastActivityAt || 0) - (a.lastActivityAt || 0));
     }
-    return dmThreadsList;
+    return dmThreadsList.filter((c) => isDmLikeConversationId(c.conversationId));
   }, [dmThreadsList, serverConversations, unreadDmMap]);
 
   // Load persisted DM threads (best-effort).

--- a/frontend/src/features/appShell/hooks/useDeleteConversationFromList.ts
+++ b/frontend/src/features/appShell/hooks/useDeleteConversationFromList.ts
@@ -20,17 +20,24 @@ export function useDeleteConversationFromList({
   setServerConversations: React.Dispatch<React.SetStateAction<ServerConversation[]>>;
   setDmThreads: React.Dispatch<React.SetStateAction<DmThreads>>;
   setUnreadDmMap: React.Dispatch<React.SetStateAction<UnreadDmMap>>;
-}): { deleteConversationFromList: (conversationIdToDelete: string) => Promise<void> } {
+}): {
+  deleteConversationFromList: (
+    conversationIdToDelete: string,
+    opts?: { skipConfirm?: boolean },
+  ) => Promise<void>;
+} {
   const deleteConversationFromList = React.useCallback(
-    async (conversationIdToDelete: string) => {
+    async (conversationIdToDelete: string, opts?: { skipConfirm?: boolean }) => {
       const convId = String(conversationIdToDelete || '').trim();
       if (!convId || !apiUrl) return;
-      const ok = await promptConfirm(
-        'Remove chat?',
-        'This removes the selected chat from your Chats list. If they message you again, it will reappear.\n\nThis does not delete message history.',
-        { confirmText: 'Remove', cancelText: 'Cancel', destructive: true },
-      );
-      if (!ok) return;
+      if (!opts?.skipConfirm) {
+        const ok = await promptConfirm(
+          'Remove chat?',
+          'This removes the selected chat from your Chats list. If they message you again, it will reappear.\n\nThis does not delete message history.',
+          { confirmText: 'Remove', cancelText: 'Cancel', destructive: true },
+        );
+        if (!ok) return;
+      }
 
       try {
         const { tokens } = await fetchAuthSession();

--- a/frontend/src/features/appShell/hooks/useLastDmConversation.ts
+++ b/frontend/src/features/appShell/hooks/useLastDmConversation.ts
@@ -36,9 +36,11 @@ export function useLastDmConversation({
     (async () => {
       try {
         const userKey = getUserStorageKey(userSub);
-        const raw =
-          (userKey ? await AsyncStorage.getItem(userKey) : null) ||
-          (await AsyncStorage.getItem(getDeviceStorageKey()));
+        // If we know the signed-in user, only trust that user's DM pointer.
+        // Device fallback is only for pre-auth restore before user attrs are available.
+        const raw = userKey
+          ? await AsyncStorage.getItem(userKey)
+          : await AsyncStorage.getItem(getDeviceStorageKey());
         const v = typeof raw === 'string' ? raw.trim() : '';
         if (!mounted) return;
         if (v.startsWith('dm#') || v.startsWith('gdm#')) {


### PR DESCRIPTION
Fix nested modal from leaving chat confirmation causing ios to freeze

Fix issue where channels were appearing in Chats

Fix issue where if a user has no active chats, clicking DM started a Direct Message to a device cached user. Now, it opens the Start DM Search instead until an active chat exists for that user, by cross referencing active chats to make sure a chat exists.